### PR TITLE
feat: Add support for Reka Flash 3.1 model

### DIFF
--- a/lalamo/model_import/model_specs/__init__.py
+++ b/lalamo/model_import/model_specs/__init__.py
@@ -7,6 +7,7 @@ from .mistral import MISTRAL_MODELS
 from .pleias import PLEIAS_MODELS
 from .polaris import POLARIS_MODELS
 from .qwen import QWEN_MODELS
+from .reka import REKA_MODELS
 
 __all__ = [
     "ALL_MODELS",
@@ -25,6 +26,7 @@ ALL_MODEL_LISTS = [
     PLEIAS_MODELS,
     POLARIS_MODELS,
     QWEN_MODELS,
+    REKA_MODELS,
 ]
 
 

--- a/lalamo/model_import/model_specs/reka.py
+++ b/lalamo/model_import/model_specs/reka.py
@@ -1,0 +1,28 @@
+from lalamo.model_import.configs import HFLlamaConfig
+
+from .common import (
+    HUGGINFACE_GENERATION_CONFIG_FILE,
+    HUGGINGFACE_TOKENIZER_FILES,
+    ModelSpec,
+    WeightsType,
+    huggingface_weight_files,
+)
+
+__all__ = ["REKA_MODELS"]
+
+REKA_MODELS = [
+    ModelSpec(
+        vendor="Reka",
+        family="Reka-Flash",
+        name="Reka-Flash-3.1",
+        size="21B",
+        quantization=None,
+        repo="RekaAI/reka-flash-3.1",
+        config_type=HFLlamaConfig,
+        config_file_name="config.json",
+        weights_file_names=huggingface_weight_files(9),  # Model has 9 shards
+        weights_type=WeightsType.SAFETENSORS,
+        tokenizer_files=(*HUGGINGFACE_TOKENIZER_FILES, HUGGINFACE_GENERATION_CONFIG_FILE),
+        use_cases=tuple(),
+    ),
+] 


### PR DESCRIPTION
- Add new model spec for RekaAI/reka-flash-3.1 (21B params)
- Configure as Llama-compatible model with HFLlamaConfig
- Set up correct weight sharding (9 safetensors files)
- Register model in ALL_MODEL_LISTS