### PR TITLE
feat: add chunked attention for DeltaNet

### DIFF
--- a/lalamo/modules/token_mixers/__init__.py
+++ b/lalamo/modules/token_mixers/__init__.py
@@ -1,7 +1,7 @@
 from lalamo.modules.common import register_config_union
 
 from .attention import Attention, AttentionConfig, AttentionResult
-from .common import TokenMixerBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 from .delta_net_attention import (
     DeltaNetAttention,
@@ -38,6 +38,7 @@ __all__ = [
     "Mamba2",
     "Mamba2Config",
     "Mamba2Result",
+    "MixerForwardPassConfig",
     "SSMStateLayer",
     "SeparableCausalConv",
     "SeparableCausalConvConfig",

--- a/lalamo/modules/token_mixers/__init__.py
+++ b/lalamo/modules/token_mixers/__init__.py
@@ -3,7 +3,12 @@ from lalamo.modules.common import register_config_union
 from .attention import Attention, AttentionConfig, AttentionResult
 from .common import TokenMixerBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
-from .delta_net_attention import DeltaNetAttention, DeltaNetAttentionConfig, DeltaNetAttentionResult
+from .delta_net_attention import (
+    DeltaNetAttention,
+    DeltaNetAttentionConfig,
+    DeltaNetAttentionResult,
+    DeltaNetForwardPassConfig,
+)
 from .mamba import Mamba2, Mamba2Config, Mamba2Result
 from .short_conv import ShortConv, ShortConvConfig, ShortConvResult
 from .state import (
@@ -27,6 +32,7 @@ __all__ = [
     "DeltaNetAttention",
     "DeltaNetAttentionConfig",
     "DeltaNetAttentionResult",
+    "DeltaNetForwardPassConfig",
     "DynamicKVCacheLayer",
     "KVCacheLayer",
     "Mamba2",

--- a/lalamo/modules/token_mixers/__init__.py
+++ b/lalamo/modules/token_mixers/__init__.py
@@ -3,12 +3,7 @@ from lalamo.modules.common import register_config_union
 from .attention import Attention, AttentionConfig, AttentionResult
 from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
-from .delta_net_attention import (
-    DeltaNetAttention,
-    DeltaNetAttentionConfig,
-    DeltaNetAttentionResult,
-    DeltaNetForwardPassConfig,
-)
+from .delta_net_attention import DeltaNetAttention, DeltaNetAttentionConfig, DeltaNetAttentionResult
 from .mamba import Mamba2, Mamba2Config, Mamba2Result
 from .short_conv import ShortConv, ShortConvConfig, ShortConvResult
 from .state import (
@@ -32,7 +27,6 @@ __all__ = [
     "DeltaNetAttention",
     "DeltaNetAttentionConfig",
     "DeltaNetAttentionResult",
-    "DeltaNetForwardPassConfig",
     "DynamicKVCacheLayer",
     "KVCacheLayer",
     "Mamba2",

--- a/lalamo/modules/token_mixers/attention.py
+++ b/lalamo/modules/token_mixers/attention.py
@@ -15,7 +15,7 @@ from lalamo.modules.normalization import Normalization, NormalizationConfig
 from lalamo.modules.rope import PositionalEmbeddings
 from lalamo.modules.utils import apply_soft_capping
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .state import DynamicKVCacheLayer, KVCacheLayer, StaticKVCacheLayer
 
 __all__ = [
@@ -377,6 +377,7 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
         state: KVCacheLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: ARG002, B008
     ) -> AttentionResult:
         queries, keys, values = vmap(self.qkv_projection, in_axes=0)(inputs)
         if self.gate_projection is not None:

--- a/lalamo/modules/token_mixers/common.py
+++ b/lalamo/modules/token_mixers/common.py
@@ -10,10 +10,16 @@ from lalamo.modules.rope import PositionalEmbeddings
 from .state.common import StateLayerBase
 
 __all__ = [
+    "MixerForwardPassConfig",
     "TokenMixerBase",
     "TokenMixerConfigBase",
     "TokenMixerResult",
 ]
+
+
+@dataclass(frozen=True)
+class MixerForwardPassConfig:
+    pass
 
 
 class TokenMixerResult[StateLayerT](NamedTuple):
@@ -63,6 +69,7 @@ class TokenMixerBase[ConfigT, StateLayerT: StateLayerBase](LalamoModule[ConfigT]
         state: StateLayerT | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: B008
     ) -> TokenMixerResult[StateLayerT]: ...
 
     @abstractmethod

--- a/lalamo/modules/token_mixers/common.py
+++ b/lalamo/modules/token_mixers/common.py
@@ -19,7 +19,12 @@ __all__ = [
 
 @dataclass(frozen=True)
 class MixerForwardPassConfig:
-    pass
+    # DeltaNet chunked attention parameters.
+    chunk_size: int = 32
+    # Minimum tokens in the last chunk before it falls back to sequential scan.
+    # If the remainder after chunking is shorter than this, the tail is processed
+    # sequentially to avoid wasting compute on mostly-padded chunks.
+    min_chunk_len: int = 16
 
 
 class TokenMixerResult[StateLayerT](NamedTuple):

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -22,10 +22,17 @@ __all__ = [
     "DeltaNetAttention",
     "DeltaNetAttentionConfig",
     "DeltaNetAttentionResult",
+    "DeltaNetForwardPassConfig",
 ]
 
 
 DeltaNetAttentionResult = TokenMixerResult[SSMStateLayer]
+
+
+@dataclass(frozen=True)
+class DeltaNetForwardPassConfig:
+    chunk_size: int = 32
+    min_chunk_len: int = 16
 
 
 def _delta_dims(
@@ -51,11 +58,6 @@ class DeltaNetAttentionConfig(TokenMixerConfigBase):
     head_dim: int
     value_head_dim: int
     kernel_size: int
-    chunk_size: int = 32
-    # Minimum tokens in the last chunk before it falls back to sequential _scan.
-    # If the remainder after chunking is shorter than this, the tail is processed
-    # sequentially to avoid wasting compute on mostly-padded chunks.
-    min_chunk_len: int = 16
 
     @property
     def rope_dim(self) -> None:
@@ -159,7 +161,6 @@ class DeltaNetAttentionConfig(TokenMixerConfigBase):
         )
 
 
-
 class DeltaNetScanResult(NamedTuple):
     outputs: Float[Array, "tokens heads value_channels"]
     final_state: Float[Array, "heads value_channels key_channels"]
@@ -253,7 +254,9 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             value_delta = value_t - jnp.sum(decayed_state * key_t[:, None, :], axis=-1)
             value_delta = value_delta * beta_t[:, None]
             updated_state = decayed_state + value_delta[:, :, None] * key_t[:, None, :]
-            output_t = einops.einsum(query_t, updated_state, "heads key_channels, heads value_channels key_channels -> heads value_channels")
+            output_t = einops.einsum(
+                query_t, updated_state, "heads key_channels, heads value_channels key_channels -> heads value_channels"
+            )
 
             propagated_state = jax.lax.cond(index < num_steps, lambda: updated_state, lambda: carry_state)
             return (index + 1, propagated_state), output_t
@@ -274,9 +277,10 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         beta: Float[Array, "tokens heads"],
         initial_state: Float[Array, "heads value_channels key_channels"],
         num_steps: Int[Array, ""] | int,
+        forward_pass_config: DeltaNetForwardPassConfig,
     ) -> DeltaNetScanResult:
-        chunk_size = self.config.chunk_size
-        min_chunk_len = self.config.min_chunk_len
+        chunk_size = forward_pass_config.chunk_size
+        min_chunk_len = forward_pass_config.min_chunk_len
         num_tokens, _, _ = queries.shape
         num_steps_arr = jnp.asarray(num_steps, dtype=jnp.int32)
         dtype = queries.dtype
@@ -321,7 +325,9 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
 
         # Phase 1: intra-chunk scan (parallel across chunks via vmap)
         def _intra_chunk_token_step(
-            carry: tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]],
+            carry: tuple[
+                Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]
+            ],
             token_inputs: DeltaNetScanInputs,
         ) -> tuple[
             tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]],
@@ -337,11 +343,26 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             new_state = decayed_state + value_delta[:, :, None] * token_inputs.keys[:, None, :]
 
             decayed_prop = prop * decay
-            prop_dot_key = einops.einsum(decayed_prop, token_inputs.keys, "heads key_channels_out key_channels_in, heads key_channels_in -> heads key_channels_out")
-            new_prop = decayed_prop - token_inputs.beta[:, None, None] * prop_dot_key[:, :, None] * token_inputs.keys[:, None, :]
+            prop_dot_key = einops.einsum(
+                decayed_prop,
+                token_inputs.keys,
+                "heads key_channels_out key_channels_in, heads key_channels_in -> heads key_channels_out",
+            )
+            new_prop = (
+                decayed_prop
+                - token_inputs.beta[:, None, None] * prop_dot_key[:, :, None] * token_inputs.keys[:, None, :]
+            )
 
-            local_output = einops.einsum(token_inputs.queries, new_state, "heads key_channels, heads value_channels key_channels -> heads value_channels")
-            correction_vec = einops.einsum(new_prop, token_inputs.queries, "heads key_channels_out key_channels_in, heads key_channels_in -> heads key_channels_out")
+            local_output = einops.einsum(
+                token_inputs.queries,
+                new_state,
+                "heads key_channels, heads value_channels key_channels -> heads value_channels",
+            )
+            correction_vec = einops.einsum(
+                new_prop,
+                token_inputs.queries,
+                "heads key_channels_out key_channels_in, heads key_channels_in -> heads key_channels_out",
+            )
 
             return (new_state, new_prop), DeltaNetTokenStepOutput(local_output, correction_vec)
 
@@ -349,7 +370,9 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             state_init = jnp.zeros((self.num_heads, self.value_head_dim, self.head_dim), dtype=dtype)
             prop_init = jnp.tile(jnp.eye(self.head_dim, dtype=dtype), (self.num_heads, 1, 1))
             (end_state, end_prop), step_outputs = jax.lax.scan(
-                _intra_chunk_token_step, (state_init, prop_init), chunk_inputs,
+                _intra_chunk_token_step,
+                (state_init, prop_init),
+                chunk_inputs,
             )
             return DeltaNetChunkScanResult(step_outputs.local_output, step_outputs.correction_vec, end_state, end_prop)
 
@@ -360,26 +383,49 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         # Phase 2: inter-chunk state propagation (sequential over num_chunks)
         def _inter_chunk_step(
             actual_state: Float[Array, "heads value_channels key_channels"],
-            chunk_data: tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]],
-        ) -> tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads value_channels key_channels"]]:
+            chunk_data: tuple[
+                Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]
+            ],
+        ) -> tuple[
+            Float[Array, "heads value_channels key_channels"], Float[Array, "heads value_channels key_channels"]
+        ]:
             local_end, prop_matrix = chunk_data
-            next_state = local_end + einops.einsum(actual_state, prop_matrix, "heads value_channels key_channels_in, heads key_channels_in key_channels_out -> heads value_channels key_channels_out")
+            next_state = local_end + einops.einsum(
+                actual_state,
+                prop_matrix,
+                "heads value_channels key_channels_in,"
+                " heads key_channels_in key_channels_out"
+                " -> heads value_channels key_channels_out",
+            )
             return next_state, actual_state
 
         final_state, chunk_initials = jax.lax.scan(
-            _inter_chunk_step, initial_state, (chunk_results.end_state, chunk_results.end_prop),
+            _inter_chunk_step,
+            initial_state,
+            (chunk_results.end_state, chunk_results.end_prop),
         )
 
         # Phase 3: apply corrections (parallel batched matmul)
-        corrections = einops.einsum(chunk_initials, chunk_results.correction_vecs, "chunk heads value_channels key_channels, chunk time heads key_channels -> chunk time heads value_channels")
+        corrections = einops.einsum(
+            chunk_initials,
+            chunk_results.correction_vecs,
+            "chunk heads value_channels key_channels,"
+            " chunk time heads key_channels"
+            " -> chunk time heads value_channels",
+        )
         outputs = chunk_results.chunk_outputs + corrections
         outputs = outputs.reshape(padded_len, self.num_heads, self.value_head_dim)[:num_chunked_tokens]
 
         if has_short_tail:
             tail_num_steps = jnp.clip(num_steps_arr - num_chunked_tokens, 0, remainder)
             tail_result = self._recurrent_scan(
-                tail_queries, tail_keys, tail_values, tail_decay, tail_beta,
-                final_state, tail_num_steps,
+                tail_queries,
+                tail_keys,
+                tail_values,
+                tail_decay,
+                tail_beta,
+                final_state,
+                tail_num_steps,
             )
             outputs = jnp.concatenate([outputs, tail_result.outputs], axis=0)
             final_state = tail_result.final_state
@@ -394,6 +440,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         state: SSMStateLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: DeltaNetForwardPassConfig = DeltaNetForwardPassConfig(),  # noqa: B008
     ) -> DeltaNetAttentionResult:
         if positional_embeddings is not None:
             raise ValueError("Positional embeddings are not supported for DeltaNetAttention.")
@@ -451,15 +498,26 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         length_without_padding = jnp.asarray(length_without_padding, dtype=jnp.int32)
         length_without_padding = jnp.clip(length_without_padding, 0, num_tokens)
 
-        if num_tokens < self.config.min_chunk_len:
+        if num_tokens < forward_pass_config.min_chunk_len:
             core_attn_out, final_state = self._recurrent_scan(
-                query, key, value, decay_factor, beta,
-                state.ssm_state, length_without_padding,
+                query,
+                key,
+                value,
+                decay_factor,
+                beta,
+                state.ssm_state,
+                length_without_padding,
             )
         else:
             core_attn_out, final_state = self._chunked_scan(
-                query, key, value, decay_factor, beta,
-                state.ssm_state, length_without_padding,
+                query,
+                key,
+                value,
+                decay_factor,
+                beta,
+                state.ssm_state,
+                length_without_padding,
+                forward_pass_config,
             )
 
         def norm_gate(x: Float[Array, " channels"], gate: Float[Array, " channels"]) -> Float[Array, " channels"]:

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -15,7 +15,7 @@ from lalamo.modules.normalization import Normalization, NormalizationConfig
 from lalamo.modules.rope import PositionalEmbeddings
 from lalamo.modules.token_mixers.state.ssm_state import SSMStateLayer
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 
 __all__ = [
@@ -440,7 +440,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         state: SSMStateLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
-        forward_pass_config: DeltaNetForwardPassConfig = DeltaNetForwardPassConfig(),  # noqa: B008
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: B008
     ) -> DeltaNetAttentionResult:
         if positional_embeddings is not None:
             raise ValueError("Positional embeddings are not supported for DeltaNetAttention.")

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -166,11 +166,11 @@ class DeltaNetScanResult(NamedTuple):
 
 
 class DeltaNetScanInputs(NamedTuple):
-    queries: Float[Array, "*batch heads key_channels"]
-    keys: Float[Array, "*batch heads key_channels"]
-    values: Float[Array, "*batch heads value_channels"]
-    decay_factor: Float[Array, "*batch heads"]
-    beta: Float[Array, "*batch heads"]
+    queries: Float[Array, "tokens heads key_channels"]
+    keys: Float[Array, "tokens heads key_channels"]
+    values: Float[Array, "tokens heads value_channels"]
+    decay_factor: Float[Array, "tokens heads"]
+    beta: Float[Array, "tokens heads"]
 
 
 class DeltaNetTokenStepOutput(NamedTuple):
@@ -277,7 +277,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
     ) -> DeltaNetScanResult:
         chunk_size = self.config.chunk_size
         min_chunk_len = self.config.min_chunk_len
-        num_tokens = queries.shape[0]
+        num_tokens, _, _ = queries.shape
         num_steps_arr = jnp.asarray(num_steps, dtype=jnp.int32)
         dtype = queries.dtype
 
@@ -305,7 +305,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             decay_factor = jnp.pad(decay_factor, ((0, pad_len), (0, 0)))
             beta = jnp.pad(beta, ((0, pad_len), (0, 0)))
 
-        padded_len = queries.shape[0]
+        padded_len, _, _ = queries.shape
         valid_mask = (jnp.arange(padded_len) < num_steps_arr).astype(dtype)
         keys = keys * valid_mask[:, None, None]
         values = values * valid_mask[:, None, None]

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -161,28 +161,28 @@ class DeltaNetAttentionConfig(TokenMixerConfigBase):
 
 
 class DeltaNetScanResult(NamedTuple):
-    outputs: Float[Array, "tokens heads head_v_dim"]
-    final_state: Float[Array, "heads head_v_dim head_k_dim"]
+    outputs: Float[Array, "tokens heads value_channels"]
+    final_state: Float[Array, "heads value_channels key_channels"]
 
 
 class DeltaNetScanInputs(NamedTuple):
-    queries: Float[Array, "*batch heads k_dim"]
-    keys: Float[Array, "*batch heads k_dim"]
-    values: Float[Array, "*batch heads v_dim"]
+    queries: Float[Array, "*batch heads key_channels"]
+    keys: Float[Array, "*batch heads key_channels"]
+    values: Float[Array, "*batch heads value_channels"]
     decay_factor: Float[Array, "*batch heads"]
     beta: Float[Array, "*batch heads"]
 
 
 class DeltaNetTokenStepOutput(NamedTuple):
-    local_output: Float[Array, "heads v_dim"]
-    correction_vec: Float[Array, "heads k_dim"]
+    local_output: Float[Array, "heads value_channels"]
+    correction_vec: Float[Array, "heads key_channels"]
 
 
 class DeltaNetChunkScanResult(NamedTuple):
-    chunk_outputs: Float[Array, "chunk_size heads v_dim"]
-    correction_vecs: Float[Array, "chunk_size heads k_dim"]
-    end_state: Float[Array, "heads v_dim k_dim"]
-    end_prop: Float[Array, "heads k_dim k_dim"]
+    chunk_outputs: Float[Array, "chunk_size heads value_channels"]
+    correction_vecs: Float[Array, "chunk_size heads key_channels"]
+    end_state: Float[Array, "heads value_channels key_channels"]
+    end_prop: Float[Array, "heads key_channels key_channels"]
 
 
 class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
@@ -224,26 +224,26 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
 
     def _scan(
         self,
-        queries: Float[Array, "tokens heads head_k_dim"],
-        keys: Float[Array, "tokens heads head_k_dim"],
-        values: Float[Array, "tokens heads head_v_dim"],
+        queries: Float[Array, "tokens heads key_channels"],
+        keys: Float[Array, "tokens heads key_channels"],
+        values: Float[Array, "tokens heads value_channels"],
         decay_factor: Float[Array, "tokens heads"],
         beta: Float[Array, "tokens heads"],
-        initial_state: Float[Array, "heads head_v_dim head_k_dim"],
+        initial_state: Float[Array, "heads value_channels key_channels"],
         num_steps: Int[Array, ""] | int,
     ) -> DeltaNetScanResult:
         def scan_fn(
-            index_and_state: tuple[Int[Array, ""], Float[Array, "heads head_v_dim head_k_dim"]],
+            index_and_state: tuple[Int[Array, ""], Float[Array, "heads value_channels key_channels"]],
             step_inputs: tuple[
-                Float[Array, "heads head_k_dim"],
-                Float[Array, "heads head_k_dim"],
-                Float[Array, "heads head_v_dim"],
+                Float[Array, "heads key_channels"],
+                Float[Array, "heads key_channels"],
+                Float[Array, "heads value_channels"],
                 Float[Array, " heads"],
                 Float[Array, " heads"],
             ],
         ) -> tuple[
-            tuple[Int[Array, ""], Float[Array, "heads head_v_dim head_k_dim"]],
-            Float[Array, "heads head_v_dim"],
+            tuple[Int[Array, ""], Float[Array, "heads value_channels key_channels"]],
+            Float[Array, "heads value_channels"],
         ]:
             index, carry_state = index_and_state
             query_t, key_t, value_t, decay_factor_t, beta_t = step_inputs
@@ -253,7 +253,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             value_delta = value_t - jnp.sum(decayed_state * key_t[:, None, :], axis=-1)
             value_delta = value_delta * beta_t[:, None]
             updated_state = decayed_state + value_delta[:, :, None] * key_t[:, None, :]
-            output_t = einops.einsum(query_t, updated_state, "heads k_dim, heads v_dim k_dim -> heads v_dim")
+            output_t = einops.einsum(query_t, updated_state, "heads key_channels, heads value_channels key_channels -> heads value_channels")
 
             propagated_state = jax.lax.cond(index < num_steps, lambda: updated_state, lambda: carry_state)
             return (index + 1, propagated_state), output_t
@@ -267,12 +267,12 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
 
     def _chunked_scan(
         self,
-        queries: Float[Array, "tokens heads head_k_dim"],
-        keys: Float[Array, "tokens heads head_k_dim"],
-        values: Float[Array, "tokens heads head_v_dim"],
+        queries: Float[Array, "tokens heads key_channels"],
+        keys: Float[Array, "tokens heads key_channels"],
+        values: Float[Array, "tokens heads value_channels"],
         decay_factor: Float[Array, "tokens heads"],
         beta: Float[Array, "tokens heads"],
-        initial_state: Float[Array, "heads head_v_dim head_k_dim"],
+        initial_state: Float[Array, "heads value_channels key_channels"],
         num_steps: Int[Array, ""] | int,
     ) -> DeltaNetScanResult:
         chunk_size = self.config.chunk_size
@@ -321,10 +321,10 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
 
         # Phase 1: intra-chunk scan (parallel across chunks via vmap)
         def _intra_chunk_token_step(
-            carry: tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
+            carry: tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]],
             token_inputs: DeltaNetScanInputs,
         ) -> tuple[
-            tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
+            tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]],
             DeltaNetTokenStepOutput,
         ]:
             state, prop = carry
@@ -337,11 +337,11 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             new_state = decayed_state + value_delta[:, :, None] * token_inputs.keys[:, None, :]
 
             decayed_prop = prop * decay
-            prop_dot_key = einops.einsum(decayed_prop, token_inputs.keys, "heads k_out k_in, heads k_in -> heads k_out")
+            prop_dot_key = einops.einsum(decayed_prop, token_inputs.keys, "heads key_channels_out key_channels_in, heads key_channels_in -> heads key_channels_out")
             new_prop = decayed_prop - token_inputs.beta[:, None, None] * prop_dot_key[:, :, None] * token_inputs.keys[:, None, :]
 
-            local_output = einops.einsum(token_inputs.queries, new_state, "heads k_dim, heads v_dim k_dim -> heads v_dim")
-            correction_vec = einops.einsum(new_prop, token_inputs.queries, "heads k_out k_in, heads k_in -> heads k_out")
+            local_output = einops.einsum(token_inputs.queries, new_state, "heads key_channels, heads value_channels key_channels -> heads value_channels")
+            correction_vec = einops.einsum(new_prop, token_inputs.queries, "heads key_channels_out key_channels_in, heads key_channels_in -> heads key_channels_out")
 
             return (new_state, new_prop), DeltaNetTokenStepOutput(local_output, correction_vec)
 
@@ -359,11 +359,11 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
 
         # Phase 2: inter-chunk state propagation (sequential over num_chunks)
         def _inter_chunk_step(
-            actual_state: Float[Array, "heads v_dim k_dim"],
-            chunk_data: tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
-        ) -> tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads v_dim k_dim"]]:
+            actual_state: Float[Array, "heads value_channels key_channels"],
+            chunk_data: tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads key_channels key_channels"]],
+        ) -> tuple[Float[Array, "heads value_channels key_channels"], Float[Array, "heads value_channels key_channels"]]:
             local_end, prop_matrix = chunk_data
-            next_state = local_end + einops.einsum(actual_state, prop_matrix, "heads v_dim k_in, heads k_in k_out -> heads v_dim k_out")
+            next_state = local_end + einops.einsum(actual_state, prop_matrix, "heads value_channels key_channels_in, heads key_channels_in key_channels_out -> heads value_channels key_channels_out")
             return next_state, actual_state
 
         final_state, chunk_initials = jax.lax.scan(
@@ -371,7 +371,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         )
 
         # Phase 3: apply corrections (parallel batched matmul)
-        corrections = einops.einsum(chunk_initials, chunk_results.correction_vecs, "chunk heads v_dim k_dim, chunk time heads k_dim -> chunk time heads v_dim")
+        corrections = einops.einsum(chunk_initials, chunk_results.correction_vecs, "chunk heads value_channels key_channels, chunk time heads key_channels -> chunk time heads value_channels")
         outputs = chunk_results.chunk_outputs + corrections
         outputs = outputs.reshape(padded_len, self.num_heads, self.value_head_dim)[:num_chunked_tokens]
 

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -222,7 +222,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
     def conv_dim(self) -> int:
         return self.key_dim * 2 + self.value_dim
 
-    def _scan(
+    def _recurrent_scan(
         self,
         queries: Float[Array, "tokens heads key_channels"],
         keys: Float[Array, "tokens heads key_channels"],
@@ -377,7 +377,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
 
         if has_short_tail:
             tail_num_steps = jnp.clip(num_steps_arr - num_chunked_tokens, 0, remainder)
-            tail_result = self._scan(
+            tail_result = self._recurrent_scan(
                 tail_queries, tail_keys, tail_values, tail_decay, tail_beta,
                 final_state, tail_num_steps,
             )
@@ -452,7 +452,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         length_without_padding = jnp.clip(length_without_padding, 0, num_tokens)
 
         if num_tokens < self.config.min_chunk_len:
-            core_attn_out, final_state = self._scan(
+            core_attn_out, final_state = self._recurrent_scan(
                 query, key, value, decay_factor, beta,
                 state.ssm_state, length_without_padding,
             )

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, replace
-from typing import Self
+from typing import NamedTuple, Self
 
+import einops
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -50,6 +51,11 @@ class DeltaNetAttentionConfig(TokenMixerConfigBase):
     head_dim: int
     value_head_dim: int
     kernel_size: int
+    chunk_size: int = 32
+    # Minimum tokens in the last chunk before it falls back to sequential _scan.
+    # If the remainder after chunking is shorter than this, the tail is processed
+    # sequentially to avoid wasting compute on mostly-padded chunks.
+    min_chunk_len: int = 16
 
     @property
     def rope_dim(self) -> None:
@@ -153,6 +159,34 @@ class DeltaNetAttentionConfig(TokenMixerConfigBase):
         )
 
 
+# Internal types for DeltaNetAttention._scan and DeltaNetAttention._chunked_scan
+
+
+class _DeltaNetScanResult(NamedTuple):
+    outputs: Float[Array, "tokens heads head_v_dim"]
+    final_state: Float[Array, "heads head_v_dim head_k_dim"]
+
+
+class _DeltaNetScanInputs(NamedTuple):
+    queries: Float[Array, "*batch heads k_dim"]
+    keys: Float[Array, "*batch heads k_dim"]
+    values: Float[Array, "*batch heads v_dim"]
+    decay_factor: Float[Array, "*batch heads"]
+    beta: Float[Array, "*batch heads"]
+
+
+class _DeltaNetTokenStepOutput(NamedTuple):
+    local_output: Float[Array, "heads v_dim"]
+    correction_vec: Float[Array, "heads k_dim"]
+
+
+class _DeltaNetChunkScanResult(NamedTuple):
+    chunk_outputs: Float[Array, "chunk_size heads v_dim"]
+    correction_vecs: Float[Array, "chunk_size heads k_dim"]
+    end_state: Float[Array, "heads v_dim k_dim"]
+    end_prop: Float[Array, "heads k_dim k_dim"]
+
+
 class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
     in_proj: LinearBase
     conv: SeparableCausalConv
@@ -199,10 +233,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         beta: Float[Array, "tokens heads"],
         initial_state: Float[Array, "heads head_v_dim head_k_dim"],
         num_steps: Int[Array, ""] | int,
-    ) -> tuple[
-        Float[Array, "tokens heads head_v_dim"],
-        Float[Array, "heads head_v_dim head_k_dim"],
-    ]:
+    ) -> _DeltaNetScanResult:
         def scan_fn(
             index_and_state: tuple[Int[Array, ""], Float[Array, "heads head_v_dim head_k_dim"]],
             step_inputs: tuple[
@@ -224,7 +255,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             value_delta = value_t - jnp.sum(decayed_state * key_t[:, None, :], axis=-1)
             value_delta = value_delta * beta_t[:, None]
             updated_state = decayed_state + value_delta[:, :, None] * key_t[:, None, :]
-            output_t = jnp.einsum("hk,hvk->hv", query_t, updated_state)
+            output_t = einops.einsum(query_t, updated_state, "heads k_dim, heads v_dim k_dim -> heads v_dim")
 
             propagated_state = jax.lax.cond(index < num_steps, lambda: updated_state, lambda: carry_state)
             return (index + 1, propagated_state), output_t
@@ -234,7 +265,128 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             (jnp.zeros((), dtype=jnp.int32), initial_state),
             (queries, keys, values, decay_factor, beta),
         )
-        return outputs, final_state
+        return _DeltaNetScanResult(outputs, final_state)
+
+    def _chunked_scan(
+        self,
+        queries: Float[Array, "tokens heads head_k_dim"],
+        keys: Float[Array, "tokens heads head_k_dim"],
+        values: Float[Array, "tokens heads head_v_dim"],
+        decay_factor: Float[Array, "tokens heads"],
+        beta: Float[Array, "tokens heads"],
+        initial_state: Float[Array, "heads head_v_dim head_k_dim"],
+        num_steps: Int[Array, ""] | int,
+    ) -> _DeltaNetScanResult:
+        chunk_size = self.config.chunk_size
+        min_chunk_len = self.config.min_chunk_len
+        num_tokens = queries.shape[0]
+        num_steps_arr = jnp.asarray(num_steps, dtype=jnp.int32)
+        dtype = queries.dtype
+
+        remainder = num_tokens % chunk_size
+        has_short_tail = 0 < remainder < min_chunk_len
+        num_chunked_tokens = num_tokens - remainder if has_short_tail else num_tokens
+
+        if has_short_tail:
+            tail_queries = queries[num_chunked_tokens:]
+            tail_keys = keys[num_chunked_tokens:]
+            tail_values = values[num_chunked_tokens:]
+            tail_decay = decay_factor[num_chunked_tokens:]
+            tail_beta = beta[num_chunked_tokens:]
+            queries = queries[:num_chunked_tokens]
+            keys = keys[:num_chunked_tokens]
+            values = values[:num_chunked_tokens]
+            decay_factor = decay_factor[:num_chunked_tokens]
+            beta = beta[:num_chunked_tokens]
+
+        pad_len = (chunk_size - num_chunked_tokens % chunk_size) % chunk_size if num_chunked_tokens > 0 else 0
+        if pad_len > 0:
+            queries = jnp.pad(queries, ((0, pad_len), (0, 0), (0, 0)))
+            keys = jnp.pad(keys, ((0, pad_len), (0, 0), (0, 0)))
+            values = jnp.pad(values, ((0, pad_len), (0, 0), (0, 0)))
+            decay_factor = jnp.pad(decay_factor, ((0, pad_len), (0, 0)))
+            beta = jnp.pad(beta, ((0, pad_len), (0, 0)))
+
+        padded_len = queries.shape[0]
+        valid_mask = (jnp.arange(padded_len) < num_steps_arr).astype(dtype)
+        keys = keys * valid_mask[:, None, None]
+        values = values * valid_mask[:, None, None]
+        beta = beta * valid_mask[:, None]
+        decay_factor = decay_factor * valid_mask[:, None]
+
+        num_chunks = padded_len // chunk_size
+        queries_c = queries.reshape(num_chunks, chunk_size, self.num_heads, self.head_dim)
+        keys_c = keys.reshape(num_chunks, chunk_size, self.num_heads, self.head_dim)
+        values_c = values.reshape(num_chunks, chunk_size, self.num_heads, self.value_head_dim)
+        decay_c = decay_factor.reshape(num_chunks, chunk_size, self.num_heads)
+        beta_c = beta.reshape(num_chunks, chunk_size, self.num_heads)
+
+        # Phase 1: intra-chunk scan (parallel across chunks via vmap)
+        def _intra_chunk_token_step(
+            carry: tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
+            token_inputs: _DeltaNetScanInputs,
+        ) -> tuple[
+            tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
+            _DeltaNetTokenStepOutput,
+        ]:
+            state, prop = carry
+
+            decay = jnp.exp(token_inputs.decay_factor)[:, None, None]
+
+            decayed_state = state * decay
+            state_dot_key = jnp.sum(decayed_state * token_inputs.keys[:, None, :], axis=-1)
+            value_delta = (token_inputs.values - state_dot_key) * token_inputs.beta[:, None]
+            new_state = decayed_state + value_delta[:, :, None] * token_inputs.keys[:, None, :]
+
+            decayed_prop = prop * decay
+            prop_dot_key = einops.einsum(decayed_prop, token_inputs.keys, "heads k_out k_in, heads k_in -> heads k_out")
+            new_prop = decayed_prop - token_inputs.beta[:, None, None] * prop_dot_key[:, :, None] * token_inputs.keys[:, None, :]
+
+            local_output = einops.einsum(token_inputs.queries, new_state, "heads k_dim, heads v_dim k_dim -> heads v_dim")
+            correction_vec = einops.einsum(new_prop, token_inputs.queries, "heads k_out k_in, heads k_in -> heads k_out")
+
+            return (new_state, new_prop), _DeltaNetTokenStepOutput(local_output, correction_vec)
+
+        def _intra_chunk_scan(chunk_inputs: _DeltaNetScanInputs) -> _DeltaNetChunkScanResult:
+            state_init = jnp.zeros((self.num_heads, self.value_head_dim, self.head_dim), dtype=dtype)
+            prop_init = jnp.tile(jnp.eye(self.head_dim, dtype=dtype), (self.num_heads, 1, 1))
+            (end_state, end_prop), step_outputs = jax.lax.scan(
+                _intra_chunk_token_step, (state_init, prop_init), chunk_inputs,
+            )
+            return _DeltaNetChunkScanResult(step_outputs.local_output, step_outputs.correction_vec, end_state, end_prop)
+
+        chunk_results = jax.vmap(_intra_chunk_scan)(
+            _DeltaNetScanInputs(queries_c, keys_c, values_c, decay_c, beta_c),
+        )
+
+        # Phase 2: inter-chunk state propagation (sequential over num_chunks)
+        def _inter_chunk_step(
+            actual_state: Float[Array, "heads v_dim k_dim"],
+            chunk_data: tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
+        ) -> tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads v_dim k_dim"]]:
+            local_end, prop_matrix = chunk_data
+            next_state = local_end + einops.einsum(actual_state, prop_matrix, "heads v_dim k_in, heads k_in k_out -> heads v_dim k_out")
+            return next_state, actual_state
+
+        final_state, chunk_initials = jax.lax.scan(
+            _inter_chunk_step, initial_state, (chunk_results.end_state, chunk_results.end_prop),
+        )
+
+        # Phase 3: apply corrections (parallel batched matmul)
+        corrections = einops.einsum(chunk_initials, chunk_results.correction_vecs, "chunk heads v_dim k_dim, chunk time heads k_dim -> chunk time heads v_dim")
+        outputs = chunk_results.chunk_outputs + corrections
+        outputs = outputs.reshape(padded_len, self.num_heads, self.value_head_dim)[:num_chunked_tokens]
+
+        if has_short_tail:
+            tail_num_steps = jnp.clip(num_steps_arr - num_chunked_tokens, 0, remainder)
+            tail_result = self._scan(
+                tail_queries, tail_keys, tail_values, tail_decay, tail_beta,
+                final_state, tail_num_steps,
+            )
+            outputs = jnp.concatenate([outputs, tail_result.outputs], axis=0)
+            final_state = tail_result.final_state
+
+        return _DeltaNetScanResult(outputs, final_state)
 
     @eqx.filter_jit
     def __call__(
@@ -301,15 +453,16 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         length_without_padding = jnp.asarray(length_without_padding, dtype=jnp.int32)
         length_without_padding = jnp.clip(length_without_padding, 0, num_tokens)
 
-        core_attn_out, final_state = self._scan(
-            query,
-            key,
-            value,
-            decay_factor,
-            beta,
-            state.ssm_state,
-            length_without_padding,
-        )
+        if num_tokens < self.config.min_chunk_len:
+            core_attn_out, final_state = self._scan(
+                query, key, value, decay_factor, beta,
+                state.ssm_state, length_without_padding,
+            )
+        else:
+            core_attn_out, final_state = self._chunked_scan(
+                query, key, value, decay_factor, beta,
+                state.ssm_state, length_without_padding,
+            )
 
         def norm_gate(x: Float[Array, " channels"], gate: Float[Array, " channels"]) -> Float[Array, " channels"]:
             return self.norm(x) * jax.nn.silu(gate.astype(jnp.float32)).astype(x.dtype)

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -22,17 +22,10 @@ __all__ = [
     "DeltaNetAttention",
     "DeltaNetAttentionConfig",
     "DeltaNetAttentionResult",
-    "DeltaNetForwardPassConfig",
 ]
 
 
 DeltaNetAttentionResult = TokenMixerResult[SSMStateLayer]
-
-
-@dataclass(frozen=True)
-class DeltaNetForwardPassConfig:
-    chunk_size: int = 32
-    min_chunk_len: int = 16
 
 
 def _delta_dims(
@@ -277,7 +270,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         beta: Float[Array, "tokens heads"],
         initial_state: Float[Array, "heads value_channels key_channels"],
         num_steps: Int[Array, ""] | int,
-        forward_pass_config: DeltaNetForwardPassConfig,
+        forward_pass_config: MixerForwardPassConfig,
     ) -> DeltaNetScanResult:
         chunk_size = forward_pass_config.chunk_size
         min_chunk_len = forward_pass_config.min_chunk_len

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -159,15 +159,13 @@ class DeltaNetAttentionConfig(TokenMixerConfigBase):
         )
 
 
-# Internal types for DeltaNetAttention._scan and DeltaNetAttention._chunked_scan
 
-
-class _DeltaNetScanResult(NamedTuple):
+class DeltaNetScanResult(NamedTuple):
     outputs: Float[Array, "tokens heads head_v_dim"]
     final_state: Float[Array, "heads head_v_dim head_k_dim"]
 
 
-class _DeltaNetScanInputs(NamedTuple):
+class DeltaNetScanInputs(NamedTuple):
     queries: Float[Array, "*batch heads k_dim"]
     keys: Float[Array, "*batch heads k_dim"]
     values: Float[Array, "*batch heads v_dim"]
@@ -175,12 +173,12 @@ class _DeltaNetScanInputs(NamedTuple):
     beta: Float[Array, "*batch heads"]
 
 
-class _DeltaNetTokenStepOutput(NamedTuple):
+class DeltaNetTokenStepOutput(NamedTuple):
     local_output: Float[Array, "heads v_dim"]
     correction_vec: Float[Array, "heads k_dim"]
 
 
-class _DeltaNetChunkScanResult(NamedTuple):
+class DeltaNetChunkScanResult(NamedTuple):
     chunk_outputs: Float[Array, "chunk_size heads v_dim"]
     correction_vecs: Float[Array, "chunk_size heads k_dim"]
     end_state: Float[Array, "heads v_dim k_dim"]
@@ -233,7 +231,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         beta: Float[Array, "tokens heads"],
         initial_state: Float[Array, "heads head_v_dim head_k_dim"],
         num_steps: Int[Array, ""] | int,
-    ) -> _DeltaNetScanResult:
+    ) -> DeltaNetScanResult:
         def scan_fn(
             index_and_state: tuple[Int[Array, ""], Float[Array, "heads head_v_dim head_k_dim"]],
             step_inputs: tuple[
@@ -265,7 +263,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             (jnp.zeros((), dtype=jnp.int32), initial_state),
             (queries, keys, values, decay_factor, beta),
         )
-        return _DeltaNetScanResult(outputs, final_state)
+        return DeltaNetScanResult(outputs, final_state)
 
     def _chunked_scan(
         self,
@@ -276,7 +274,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         beta: Float[Array, "tokens heads"],
         initial_state: Float[Array, "heads head_v_dim head_k_dim"],
         num_steps: Int[Array, ""] | int,
-    ) -> _DeltaNetScanResult:
+    ) -> DeltaNetScanResult:
         chunk_size = self.config.chunk_size
         min_chunk_len = self.config.min_chunk_len
         num_tokens = queries.shape[0]
@@ -324,10 +322,10 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         # Phase 1: intra-chunk scan (parallel across chunks via vmap)
         def _intra_chunk_token_step(
             carry: tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
-            token_inputs: _DeltaNetScanInputs,
+            token_inputs: DeltaNetScanInputs,
         ) -> tuple[
             tuple[Float[Array, "heads v_dim k_dim"], Float[Array, "heads k_dim k_dim"]],
-            _DeltaNetTokenStepOutput,
+            DeltaNetTokenStepOutput,
         ]:
             state, prop = carry
 
@@ -345,18 +343,18 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             local_output = einops.einsum(token_inputs.queries, new_state, "heads k_dim, heads v_dim k_dim -> heads v_dim")
             correction_vec = einops.einsum(new_prop, token_inputs.queries, "heads k_out k_in, heads k_in -> heads k_out")
 
-            return (new_state, new_prop), _DeltaNetTokenStepOutput(local_output, correction_vec)
+            return (new_state, new_prop), DeltaNetTokenStepOutput(local_output, correction_vec)
 
-        def _intra_chunk_scan(chunk_inputs: _DeltaNetScanInputs) -> _DeltaNetChunkScanResult:
+        def _intra_chunk_scan(chunk_inputs: DeltaNetScanInputs) -> DeltaNetChunkScanResult:
             state_init = jnp.zeros((self.num_heads, self.value_head_dim, self.head_dim), dtype=dtype)
             prop_init = jnp.tile(jnp.eye(self.head_dim, dtype=dtype), (self.num_heads, 1, 1))
             (end_state, end_prop), step_outputs = jax.lax.scan(
                 _intra_chunk_token_step, (state_init, prop_init), chunk_inputs,
             )
-            return _DeltaNetChunkScanResult(step_outputs.local_output, step_outputs.correction_vec, end_state, end_prop)
+            return DeltaNetChunkScanResult(step_outputs.local_output, step_outputs.correction_vec, end_state, end_prop)
 
         chunk_results = jax.vmap(_intra_chunk_scan)(
-            _DeltaNetScanInputs(queries_c, keys_c, values_c, decay_c, beta_c),
+            DeltaNetScanInputs(queries_c, keys_c, values_c, decay_c, beta_c),
         )
 
         # Phase 2: inter-chunk state propagation (sequential over num_chunks)
@@ -386,7 +384,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
             outputs = jnp.concatenate([outputs, tail_result.outputs], axis=0)
             final_state = tail_result.final_state
 
-        return _DeltaNetScanResult(outputs, final_state)
+        return DeltaNetScanResult(outputs, final_state)
 
     @eqx.filter_jit
     def __call__(

--- a/lalamo/modules/token_mixers/mamba.py
+++ b/lalamo/modules/token_mixers/mamba.py
@@ -15,7 +15,7 @@ from lalamo.modules.linear import LinearBase, LinearConfig
 from lalamo.modules.rope import PositionalEmbeddings
 from lalamo.modules.token_mixers.state.ssm_state import SSMStateLayer
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 
 __all__ = [
@@ -509,6 +509,7 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
         state: SSMStateLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: ARG002, B008
     ) -> Mamba2Result:
         if positional_embeddings is not None:
             raise ValueError("Positional embeddings are not supported for Mamba2.")

--- a/lalamo/modules/token_mixers/short_conv.py
+++ b/lalamo/modules/token_mixers/short_conv.py
@@ -10,7 +10,7 @@ from lalamo.modules.common import PositionalEmbeddingSelector
 from lalamo.modules.linear import LinearBase, LinearConfig
 from lalamo.modules.rope import PositionalEmbeddings
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 from .state import ShortConvStateLayer
 
@@ -116,6 +116,7 @@ class ShortConv(TokenMixerBase[ShortConvConfig, ShortConvStateLayer]):
         state: ShortConvStateLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: ARG002, B008
     ) -> TokenMixerResult[ShortConvStateLayer]:
         if positional_embeddings is not None:
             raise ValueError("Positional embeddings are not supported for ShortConv.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,10 @@ fish-speech = { git="https://github.com/trymirai/fish-speech.git", tag="c6dd030"
 # addopts = ["--dist=loadgroup"]
 # log_cli = true
 # log_cli_level = "INFO"
-markers = ["fast: quick smoke tests"]
+markers = [
+    "fast: quick smoke tests",
+    "benchmark: slow benchmarks that require model downloads (opt-in via -m benchmark)",
+]
 
 [tool.pytest_env]
 JAX_DEBUG_NANS = "True"

--- a/tests/speed/test_delta_net_ttft.py
+++ b/tests/speed/test_delta_net_ttft.py
@@ -1,0 +1,132 @@
+"""Benchmark time-to-first-token for DeltaNet chunked vs sequential scan.
+
+Loads Qwen3.5-0.8B and measures forward pass latency with ~2048 token input.
+Run with: uv run pytest tests/speed/test_delta_net_ttft.py -v -s
+"""
+
+import time
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+from lalamo.model_import.common import import_model
+from lalamo.modules.token_mixers.delta_net_attention import DeltaNetAttention
+
+MODEL_REPO = "Qwen/Qwen3.5-0.8B"
+NUM_TOKENS = 2048
+NUM_WARMUP = 2
+NUM_RUNS = 5
+
+
+def _print_times(label: str, times: list[float], num_tokens: int) -> None:
+    median = sorted(times)[len(times) // 2]
+    print(f"\n[{label}] {num_tokens} tokens, {NUM_RUNS} runs:")
+    print(f"  Median: {median:.3f}s")
+    print(f"  Min:    {min(times):.3f}s")
+    print(f"  Max:    {max(times):.3f}s")
+    print(f"  All:    {[f'{t:.3f}' for t in times]}")
+
+
+def _measure(fn, num_runs: int = NUM_RUNS, num_warmup: int = NUM_WARMUP) -> list[float]:
+    for _ in range(num_warmup):
+        fn()
+    times = []
+    for _ in range(num_runs):
+        start = time.perf_counter()
+        fn()
+        elapsed = time.perf_counter() - start
+        times.append(elapsed)
+    return times
+
+
+@pytest.fixture(scope="module")
+def qwen35_model():
+    model, _ = import_model(
+        MODEL_REPO,
+        context_length=NUM_TOKENS,
+        precision=jnp.float32,
+    )
+    return model.model
+
+
+def _swap_chunk_size(decoder, chunk_size: int, min_chunk_len: int | None = None):
+    """Replace all DeltaNet layers' chunk_size (and optionally min_chunk_len)."""
+    from dataclasses import replace as dc_replace
+
+    leaves, treedef = jax.tree.flatten(decoder, is_leaf=lambda x: isinstance(x, DeltaNetAttention))
+    new_leaves = []
+    for leaf in leaves:
+        if isinstance(leaf, DeltaNetAttention):
+            overrides = {"chunk_size": chunk_size}
+            if min_chunk_len is not None:
+                overrides["min_chunk_len"] = min_chunk_len
+            new_config = dc_replace(leaf.config, **overrides)
+            leaf = DeltaNetAttention(
+                new_config,
+                in_proj=leaf.in_proj,
+                conv=leaf.conv,
+                out_proj=leaf.out_proj,
+                norm=leaf.norm,
+                dt_bias=leaf.dt_bias,
+                a_log=leaf.a_log,
+                num_heads=leaf.num_heads,
+                num_groups=leaf.num_groups,
+                head_dim=leaf.head_dim,
+                value_head_dim=leaf.value_head_dim,
+                kernel_size=leaf.kernel_size,
+            )
+        new_leaves.append(leaf)
+    return treedef.unflatten(new_leaves)
+
+
+def test_full_model_ttft(qwen35_model) -> None:
+    """Measure full model TTFT: chunked scan vs effectively-sequential (chunk_size > seq_len)."""
+    token_ids = jnp.arange(0, NUM_TOKENS, dtype=jnp.int32)[None, :]
+    token_positions = jnp.arange(0, NUM_TOKENS, dtype=jnp.int32)[None, :]
+
+    def make_runner(model):
+        def run():
+            result = model(
+                token_ids=token_ids,
+                token_positions=token_positions,
+                return_updated_state=False,
+                return_activation_trace=False,
+            )
+            jax.block_until_ready(result.logits)
+
+        return run
+
+    configs = [
+        ("chunk_size=16", 16),
+        ("chunk_size=32", 32),
+        ("chunk_size=64", 64),
+        ("chunk_size=128", 128),
+        ("chunk_size=256", 256),
+        ("chunk_size=1024", 1024),
+        ("sequential", NUM_TOKENS + 1),
+    ]
+
+    # Pre-compile all configs to avoid JIT overhead in measurements
+    runners = {}
+    for label, cs in configs:
+        if label == "sequential":
+            model = _swap_chunk_size(qwen35_model, cs, min_chunk_len=NUM_TOKENS + 1)
+        else:
+            model = _swap_chunk_size(qwen35_model, cs)
+        runner = make_runner(model)
+        runner()  # trigger JIT compilation
+        jax.clear_caches()  # free compilation memory, keep compiled code
+        runners[label] = runner
+
+    results = {}
+    for label, _ in configs:
+        times = _measure(runners[label])
+        _print_times(label, times, NUM_TOKENS)
+        results[label] = sorted(times)[len(times) // 2]
+
+    baseline = results["sequential"]
+    print("\n  Speedups vs sequential:")
+    for label, median in results.items():
+        print(f"    {label}: {baseline / median:.2f}x")

--- a/tests/speed/test_delta_net_ttft.py
+++ b/tests/speed/test_delta_net_ttft.py
@@ -4,6 +4,7 @@ Loads Qwen3.5-0.8B and measures forward pass latency with ~2048 token input.
 Run with: uv run pytest tests/speed/test_delta_net_ttft.py -v -s
 """
 
+import os
 import time
 
 import equinox as eqx
@@ -13,6 +14,8 @@ import pytest
 
 from lalamo.model_import.common import import_model
 from lalamo.modules.token_mixers.delta_net_attention import DeltaNetAttention
+
+_RUN_BENCHMARKS = os.environ.get("RUN_BENCHMARKS", "0") == "1"
 
 MODEL_REPO = "Qwen/Qwen3.5-0.8B"
 NUM_TOKENS = 2048
@@ -81,6 +84,8 @@ def _swap_chunk_size(decoder, chunk_size: int, min_chunk_len: int | None = None)
     return treedef.unflatten(new_leaves)
 
 
+@pytest.mark.benchmark
+@pytest.mark.skipif(not _RUN_BENCHMARKS, reason="Set RUN_BENCHMARKS=1 to run TTFT benchmarks")
 def test_full_model_ttft(qwen35_model) -> None:
     """Measure full model TTFT: chunked scan vs effectively-sequential (chunk_size > seq_len)."""
     token_ids = jnp.arange(0, NUM_TOKENS, dtype=jnp.int32)[None, :]

--- a/tests/unit/test_delta_net.py
+++ b/tests/unit/test_delta_net.py
@@ -195,7 +195,7 @@ def test_chunked_scan_matches_sequential(
         else jnp.zeros(state_shape, dtype=jnp.float32)
     )
 
-    out_seq, state_seq = module._scan(
+    out_seq, state_seq = module._recurrent_scan(
         queries, keys, values, decay_factor, beta, initial_state, num_steps,
     )
     out_chunk, state_chunk = module._chunked_scan(
@@ -289,7 +289,7 @@ def test_delta_net_chunked_with_gqa() -> None:
     beta = jax.nn.sigmoid(jax.random.normal(k5, (seq_len, 4)))
     initial_state = jax.random.normal(k6, (4, 8, 8)) * 0.1
 
-    out_seq, state_seq = module_seq._scan(
+    out_seq, state_seq = module_seq._recurrent_scan(
         queries, keys, values, decay_factor, beta, initial_state, seq_len,
     )
     out_chunk, state_chunk = module_seq._chunked_scan(
@@ -358,7 +358,7 @@ def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
     beta = jax.nn.sigmoid(jax.random.normal(k5, (seq_len, module.num_heads)))
     initial_state = jax.random.normal(k6, (module.num_heads, module.value_head_dim, module.head_dim)) * 0.1
 
-    out_seq, state_seq = module._scan(
+    out_seq, state_seq = module._recurrent_scan(
         queries, keys, values, decay_factor, beta, initial_state, seq_len,
     )
     out_chunk, state_chunk = module._chunked_scan(

--- a/tests/unit/test_delta_net.py
+++ b/tests/unit/test_delta_net.py
@@ -2,6 +2,9 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from lalamo.common import ParameterPath
 from lalamo.model_import.loaders.huggingface import load_delta_net_attention
@@ -12,6 +15,7 @@ from lalamo.modules import (
     SeparableCausalConvConfig,
     UpcastMode,
 )
+from lalamo.modules.token_mixers.delta_net_attention import DeltaNetAttention
 from lalamo.modules.torch_interop import torch_to_jax
 from tests.common import assert_close
 
@@ -109,3 +113,305 @@ def test_delta_net_attention_matches_hf() -> None:
         atol=1e-3,
         fraction_of_allowed_violations=0.02,
     )
+
+
+def _make_delta_net(
+    chunk_size: int = 4,
+    num_heads: int = 2,
+    num_groups: int = 2,
+) -> DeltaNetAttention:
+    precision = jnp.float32
+    norm_config = NormalizationConfig(
+        scale_precision=precision,
+        accumulation_precision=precision,
+        epsilon=1e-6,
+        scale_offset=None,
+        upcast_mode=UpcastMode.ONLY_NORMALIZATION,
+        subtract_mean=False,
+    )
+    config = DeltaNetAttentionConfig(
+        in_proj_config=FullPrecisionLinearConfig(precision=precision),
+        conv_config=SeparableCausalConvConfig(precision=precision, has_biases=False),
+        out_proj_config=FullPrecisionLinearConfig(precision=precision),
+        norm_config=norm_config,
+        num_heads=num_heads,
+        num_groups=num_groups,
+        head_dim=8,
+        value_head_dim=8,
+        kernel_size=3,
+        chunk_size=chunk_size,
+    )
+    return config.random_init(model_dim=64, key=jax.random.PRNGKey(42))
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "num_steps", "chunk_size", "use_nonzero_state"),
+    [
+        # No padding (num_steps == seq_len), zero initial state
+        (1, 1, 4, False),
+        (3, 3, 4, False),
+        (4, 4, 4, False),
+        (7, 7, 4, False),
+        (8, 8, 4, False),
+        (16, 16, 4, False),
+        # Padding (num_steps < seq_len), zero initial state
+        (8, 3, 4, False),
+        (8, 4, 4, False),
+        (8, 7, 4, False),
+        (16, 1, 4, False),
+        (16, 9, 4, False),
+        (8, 0, 4, False),
+        # Non-zero initial state (tests Phase 2 propagation + Phase 3 correction)
+        (1, 1, 4, True),
+        (7, 7, 4, True),
+        (8, 8, 4, True),
+        (16, 16, 4, True),
+        (8, 3, 4, True),
+        (16, 9, 4, True),
+        # Degenerate chunk_size=1
+        (4, 4, 1, False),
+        (4, 4, 1, True),
+        # chunk_size > seq_len
+        (3, 3, 16, False),
+        (3, 3, 16, True),
+    ],
+)
+def test_chunked_scan_matches_sequential(
+    seq_len: int, num_steps: int, chunk_size: int, use_nonzero_state: bool,
+) -> None:
+    module = _make_delta_net(chunk_size=chunk_size)
+    k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(0), 6)
+
+    queries = jax.random.normal(k1, (seq_len, module.num_heads, module.head_dim))
+    keys = jax.random.normal(k2, (seq_len, module.num_heads, module.head_dim))
+    values = jax.random.normal(k3, (seq_len, module.num_heads, module.value_head_dim))
+    decay_factor = -jnp.abs(jax.random.normal(k4, (seq_len, module.num_heads)))
+    beta = jax.nn.sigmoid(jax.random.normal(k5, (seq_len, module.num_heads)))
+
+    state_shape = (module.num_heads, module.value_head_dim, module.head_dim)
+    initial_state = (
+        jax.random.normal(k6, state_shape) * 0.1
+        if use_nonzero_state
+        else jnp.zeros(state_shape, dtype=jnp.float32)
+    )
+
+    out_seq, state_seq = module._scan(
+        queries, keys, values, decay_factor, beta, initial_state, num_steps,
+    )
+    out_chunk, state_chunk = module._chunked_scan(
+        queries, keys, values, decay_factor, beta, initial_state, num_steps,
+    )
+
+    valid = max(num_steps, 0)
+    if valid > 0:
+        assert_close(result=out_chunk[:valid], reference=out_seq[:valid], atol=1e-5)
+    assert_close(result=state_chunk, reference=state_seq, atol=1e-5)
+
+
+@settings(max_examples=10, deadline=None)
+@given(
+    seqlen=st.integers(min_value=1, max_value=32),
+    padding=st.integers(min_value=0, max_value=32),
+    seed=st.integers(min_value=0, max_value=2**32 - 1),
+)
+def test_delta_net_state_respects_length_without_padding(
+    seqlen: int,
+    padding: int,
+    seed: int,
+) -> None:
+    module = _make_delta_net(chunk_size=4)
+    full_input = jax.random.normal(
+        jax.random.PRNGKey(seed),
+        (seqlen + padding, module.model_dim),
+        dtype=jnp.float32,
+    )
+
+    padded_result = module(
+        full_input,
+        positional_embeddings=None,
+        state=None,
+        return_updated_state=True,
+        length_without_padding=seqlen,
+    )
+    reference_result = module(
+        full_input[:seqlen],
+        positional_embeddings=None,
+        state=None,
+        return_updated_state=True,
+        length_without_padding=None,
+    )
+
+    assert padded_result.state is not None
+    assert reference_result.state is not None
+
+    assert_close(result=padded_result.outputs[:seqlen], reference=reference_result.outputs)
+    assert_close(result=padded_result.state.ssm_state, reference=reference_result.state.ssm_state)
+    assert_close(result=padded_result.state.conv_state, reference=reference_result.state.conv_state)
+
+
+@pytest.mark.parametrize("seq_len", [8, 16])
+def test_delta_net_chunked_preserves_causality(seq_len: int) -> None:
+    module = _make_delta_net(chunk_size=4)
+    inputs = jax.random.normal(jax.random.PRNGKey(123), (seq_len, module.model_dim))
+
+    result_original = module(inputs, positional_embeddings=None)
+
+    midpoint = seq_len // 2
+    modified_inputs = inputs.at[midpoint:].set(
+        jax.random.normal(jax.random.PRNGKey(999), (seq_len - midpoint, module.model_dim)),
+    )
+    result_modified = module(modified_inputs, positional_embeddings=None)
+
+    assert_close(
+        result=result_modified.outputs[:midpoint],
+        reference=result_original.outputs[:midpoint],
+    )
+
+
+def test_delta_net_chunked_with_gqa() -> None:
+    module = _make_delta_net(chunk_size=4, num_heads=4, num_groups=2)
+    inputs = jax.random.normal(jax.random.PRNGKey(7), (12, module.model_dim))
+
+    result = module(inputs, positional_embeddings=None, return_updated_state=True)
+    assert result.outputs.shape == (12, module.model_dim)
+    assert result.state is not None
+
+    # Verify chunked matches sequential with GQA by running the scan-level comparison
+    # after __call__ projections (the repeat happens before _scan/_chunked_scan)
+    module_seq = _make_delta_net(chunk_size=4, num_heads=4, num_groups=2)
+    k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(3), 6)
+    seq_len = 9
+
+    queries = jax.random.normal(k1, (seq_len, 4, 8))
+    keys = jax.random.normal(k2, (seq_len, 4, 8))
+    values = jax.random.normal(k3, (seq_len, 4, 8))
+    decay_factor = -jnp.abs(jax.random.normal(k4, (seq_len, 4)))
+    beta = jax.nn.sigmoid(jax.random.normal(k5, (seq_len, 4)))
+    initial_state = jax.random.normal(k6, (4, 8, 8)) * 0.1
+
+    out_seq, state_seq = module_seq._scan(
+        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+    )
+    out_chunk, state_chunk = module_seq._chunked_scan(
+        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+    )
+
+    assert_close(result=out_chunk, reference=out_seq, atol=1e-5)
+    assert_close(result=state_chunk, reference=state_seq, atol=1e-5)
+
+
+def test_delta_net_multi_step_generation() -> None:
+    module = _make_delta_net(chunk_size=4)
+    k1, k2, k3 = jax.random.split(jax.random.PRNGKey(42), 3)
+    chunk1 = jax.random.normal(k1, (6, module.model_dim))
+    chunk2 = jax.random.normal(k2, (5, module.model_dim))
+    chunk3 = jax.random.normal(k3, (7, module.model_dim))
+
+    # Multi-step: process chunks sequentially, passing state forward
+    result1 = module(chunk1, positional_embeddings=None, return_updated_state=True)
+    assert result1.state is not None
+    result2 = module(chunk2, positional_embeddings=None, state=result1.state, return_updated_state=True)
+    assert result2.state is not None
+    result3 = module(chunk3, positional_embeddings=None, state=result2.state, return_updated_state=True)
+
+    # Single-step: process all at once
+    full_input = jnp.concatenate([chunk1, chunk2, chunk3], axis=0)
+    result_full = module(full_input, positional_embeddings=None, return_updated_state=True)
+
+    # Outputs must match
+    multi_outputs = jnp.concatenate([result1.outputs, result2.outputs, result3.outputs], axis=0)
+    assert_close(result=multi_outputs, reference=result_full.outputs, atol=1e-4)
+
+    # Final state must match
+    assert result3.state is not None
+    assert result_full.state is not None
+    assert_close(result=result3.state.ssm_state, reference=result_full.state.ssm_state, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    ("chunk_size_a", "chunk_size_b"),
+    [(1, 4), (2, 8), (3, 7), (4, 16)],
+)
+def test_delta_net_output_invariant_to_chunk_size(chunk_size_a: int, chunk_size_b: int) -> None:
+    module_a = _make_delta_net(chunk_size=chunk_size_a)
+    module_b = _make_delta_net(chunk_size=chunk_size_b)
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (12, module_a.model_dim))
+
+    result_a = module_a(inputs, positional_embeddings=None, return_updated_state=True)
+    result_b = module_b(inputs, positional_embeddings=None, return_updated_state=True)
+
+    assert_close(result=result_a.outputs, reference=result_b.outputs, atol=1e-5)
+    assert result_a.state is not None
+    assert result_b.state is not None
+    assert_close(result=result_a.state.ssm_state, reference=result_b.state.ssm_state, atol=1e-5)
+
+
+@pytest.mark.parametrize("seq_len", [128, 512])
+def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
+    module = _make_delta_net(chunk_size=64)
+    k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(0), 6)
+
+    queries = jax.random.normal(k1, (seq_len, module.num_heads, module.head_dim))
+    keys = jax.random.normal(k2, (seq_len, module.num_heads, module.head_dim))
+    values = jax.random.normal(k3, (seq_len, module.num_heads, module.value_head_dim))
+    decay_factor = -jnp.abs(jax.random.normal(k4, (seq_len, module.num_heads)))
+    beta = jax.nn.sigmoid(jax.random.normal(k5, (seq_len, module.num_heads)))
+    initial_state = jax.random.normal(k6, (module.num_heads, module.value_head_dim, module.head_dim)) * 0.1
+
+    out_seq, state_seq = module._scan(
+        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+    )
+    out_chunk, state_chunk = module._chunked_scan(
+        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+    )
+
+    assert_close(result=out_chunk, reference=out_seq, atol=2e-3, fraction_of_allowed_violations=0.01)
+    assert_close(result=state_chunk, reference=state_seq, atol=2e-3, fraction_of_allowed_violations=0.01)
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "chunk_size", "min_chunk_len"),
+    [
+        # seq_len < min_chunk_len: __call__ routes entirely to _scan
+        (3, 8, 4, ),
+        (1, 4, 2),
+        # Tail falls back to _scan: remainder=2 < min_chunk_len=3
+        (10, 8, 3),
+        # Tail falls back to _scan: remainder=1 < min_chunk_len=4
+        (9, 8, 4),
+        # No tail: remainder=0 (exact multiple)
+        (16, 8, 4),
+        # No tail: remainder=4 >= min_chunk_len=4 (padded normally)
+        (12, 8, 4),
+        # Large min_chunk_len forces most to _scan tail
+        (5, 4, 3),
+    ],
+)
+def test_min_chunk_len_matches_sequential(seq_len: int, chunk_size: int, min_chunk_len: int) -> None:
+    from dataclasses import replace as dc_replace
+
+    module = _make_delta_net(chunk_size=chunk_size)
+    module_with_min = DeltaNetAttention(
+        dc_replace(module.config, min_chunk_len=min_chunk_len),
+        in_proj=module.in_proj,
+        conv=module.conv,
+        out_proj=module.out_proj,
+        norm=module.norm,
+        dt_bias=module.dt_bias,
+        a_log=module.a_log,
+        num_heads=module.num_heads,
+        num_groups=module.num_groups,
+        head_dim=module.head_dim,
+        value_head_dim=module.value_head_dim,
+        kernel_size=module.kernel_size,
+    )
+
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (seq_len, module.model_dim))
+
+    result = module_with_min(inputs, positional_embeddings=None, return_updated_state=True)
+    reference = module(inputs, positional_embeddings=None, return_updated_state=True)
+
+    assert_close(result=result.outputs, reference=reference.outputs, atol=1e-5)
+    assert result.state is not None
+    assert reference.state is not None
+    assert_close(result=result.state.ssm_state, reference=reference.state.ssm_state, atol=1e-5)

--- a/tests/unit/test_delta_net.py
+++ b/tests/unit/test_delta_net.py
@@ -15,7 +15,7 @@ from lalamo.modules import (
     SeparableCausalConvConfig,
     UpcastMode,
 )
-from lalamo.modules.token_mixers.delta_net_attention import DeltaNetAttention
+from lalamo.modules.token_mixers.delta_net_attention import DeltaNetAttention, DeltaNetForwardPassConfig
 from lalamo.modules.torch_interop import torch_to_jax
 from tests.common import assert_close
 
@@ -116,7 +116,6 @@ def test_delta_net_attention_matches_hf() -> None:
 
 
 def _make_delta_net(
-    chunk_size: int = 4,
     num_heads: int = 2,
     num_groups: int = 2,
 ) -> DeltaNetAttention:
@@ -139,7 +138,6 @@ def _make_delta_net(
         head_dim=8,
         value_head_dim=8,
         kernel_size=3,
-        chunk_size=chunk_size,
     )
     return config.random_init(model_dim=64, key=jax.random.PRNGKey(42))
 
@@ -177,9 +175,13 @@ def _make_delta_net(
     ],
 )
 def test_chunked_scan_matches_sequential(
-    seq_len: int, num_steps: int, chunk_size: int, use_nonzero_state: bool,
+    seq_len: int,
+    num_steps: int,
+    chunk_size: int,
+    use_nonzero_state: bool,
 ) -> None:
-    module = _make_delta_net(chunk_size=chunk_size)
+    module = _make_delta_net()
+    fpc = DeltaNetForwardPassConfig(chunk_size=chunk_size)
     k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(0), 6)
 
     queries = jax.random.normal(k1, (seq_len, module.num_heads, module.head_dim))
@@ -190,16 +192,27 @@ def test_chunked_scan_matches_sequential(
 
     state_shape = (module.num_heads, module.value_head_dim, module.head_dim)
     initial_state = (
-        jax.random.normal(k6, state_shape) * 0.1
-        if use_nonzero_state
-        else jnp.zeros(state_shape, dtype=jnp.float32)
+        jax.random.normal(k6, state_shape) * 0.1 if use_nonzero_state else jnp.zeros(state_shape, dtype=jnp.float32)
     )
 
     out_seq, state_seq = module._recurrent_scan(
-        queries, keys, values, decay_factor, beta, initial_state, num_steps,
+        queries,
+        keys,
+        values,
+        decay_factor,
+        beta,
+        initial_state,
+        num_steps,
     )
     out_chunk, state_chunk = module._chunked_scan(
-        queries, keys, values, decay_factor, beta, initial_state, num_steps,
+        queries,
+        keys,
+        values,
+        decay_factor,
+        beta,
+        initial_state,
+        num_steps,
+        fpc,
     )
 
     valid = max(num_steps, 0)
@@ -219,7 +232,8 @@ def test_delta_net_state_respects_length_without_padding(
     padding: int,
     seed: int,
 ) -> None:
-    module = _make_delta_net(chunk_size=4)
+    module = _make_delta_net()
+    fpc = DeltaNetForwardPassConfig(chunk_size=4)
     full_input = jax.random.normal(
         jax.random.PRNGKey(seed),
         (seqlen + padding, module.model_dim),
@@ -232,6 +246,7 @@ def test_delta_net_state_respects_length_without_padding(
         state=None,
         return_updated_state=True,
         length_without_padding=seqlen,
+        forward_pass_config=fpc,
     )
     reference_result = module(
         full_input[:seqlen],
@@ -239,6 +254,7 @@ def test_delta_net_state_respects_length_without_padding(
         state=None,
         return_updated_state=True,
         length_without_padding=None,
+        forward_pass_config=fpc,
     )
 
     assert padded_result.state is not None
@@ -251,16 +267,17 @@ def test_delta_net_state_respects_length_without_padding(
 
 @pytest.mark.parametrize("seq_len", [8, 16])
 def test_delta_net_chunked_preserves_causality(seq_len: int) -> None:
-    module = _make_delta_net(chunk_size=4)
+    module = _make_delta_net()
+    fpc = DeltaNetForwardPassConfig(chunk_size=4)
     inputs = jax.random.normal(jax.random.PRNGKey(123), (seq_len, module.model_dim))
 
-    result_original = module(inputs, positional_embeddings=None)
+    result_original = module(inputs, positional_embeddings=None, forward_pass_config=fpc)
 
     midpoint = seq_len // 2
     modified_inputs = inputs.at[midpoint:].set(
         jax.random.normal(jax.random.PRNGKey(999), (seq_len - midpoint, module.model_dim)),
     )
-    result_modified = module(modified_inputs, positional_embeddings=None)
+    result_modified = module(modified_inputs, positional_embeddings=None, forward_pass_config=fpc)
 
     assert_close(
         result=result_modified.outputs[:midpoint],
@@ -269,16 +286,17 @@ def test_delta_net_chunked_preserves_causality(seq_len: int) -> None:
 
 
 def test_delta_net_chunked_with_gqa() -> None:
-    module = _make_delta_net(chunk_size=4, num_heads=4, num_groups=2)
+    module = _make_delta_net(num_heads=4, num_groups=2)
+    fpc = DeltaNetForwardPassConfig(chunk_size=4)
     inputs = jax.random.normal(jax.random.PRNGKey(7), (12, module.model_dim))
 
-    result = module(inputs, positional_embeddings=None, return_updated_state=True)
+    result = module(inputs, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc)
     assert result.outputs.shape == (12, module.model_dim)
     assert result.state is not None
 
     # Verify chunked matches sequential with GQA by running the scan-level comparison
     # after __call__ projections (the repeat happens before _scan/_chunked_scan)
-    module_seq = _make_delta_net(chunk_size=4, num_heads=4, num_groups=2)
+    module_seq = _make_delta_net(num_heads=4, num_groups=2)
     k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(3), 6)
     seq_len = 9
 
@@ -290,10 +308,23 @@ def test_delta_net_chunked_with_gqa() -> None:
     initial_state = jax.random.normal(k6, (4, 8, 8)) * 0.1
 
     out_seq, state_seq = module_seq._recurrent_scan(
-        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+        queries,
+        keys,
+        values,
+        decay_factor,
+        beta,
+        initial_state,
+        seq_len,
     )
     out_chunk, state_chunk = module_seq._chunked_scan(
-        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+        queries,
+        keys,
+        values,
+        decay_factor,
+        beta,
+        initial_state,
+        seq_len,
+        fpc,
     )
 
     assert_close(result=out_chunk, reference=out_seq, atol=1e-5)
@@ -301,22 +332,40 @@ def test_delta_net_chunked_with_gqa() -> None:
 
 
 def test_delta_net_multi_step_generation() -> None:
-    module = _make_delta_net(chunk_size=4)
+    module = _make_delta_net()
+    fpc = DeltaNetForwardPassConfig(chunk_size=4)
     k1, k2, k3 = jax.random.split(jax.random.PRNGKey(42), 3)
     chunk1 = jax.random.normal(k1, (6, module.model_dim))
     chunk2 = jax.random.normal(k2, (5, module.model_dim))
     chunk3 = jax.random.normal(k3, (7, module.model_dim))
 
     # Multi-step: process chunks sequentially, passing state forward
-    result1 = module(chunk1, positional_embeddings=None, return_updated_state=True)
+    result1 = module(
+        chunk1,
+        positional_embeddings=None,
+        return_updated_state=True,
+        forward_pass_config=fpc,
+    )
     assert result1.state is not None
-    result2 = module(chunk2, positional_embeddings=None, state=result1.state, return_updated_state=True)
+    result2 = module(
+        chunk2,
+        positional_embeddings=None,
+        state=result1.state,
+        return_updated_state=True,
+        forward_pass_config=fpc,
+    )
     assert result2.state is not None
-    result3 = module(chunk3, positional_embeddings=None, state=result2.state, return_updated_state=True)
+    result3 = module(
+        chunk3,
+        positional_embeddings=None,
+        state=result2.state,
+        return_updated_state=True,
+        forward_pass_config=fpc,
+    )
 
     # Single-step: process all at once
     full_input = jnp.concatenate([chunk1, chunk2, chunk3], axis=0)
-    result_full = module(full_input, positional_embeddings=None, return_updated_state=True)
+    result_full = module(full_input, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc)
 
     # Outputs must match
     multi_outputs = jnp.concatenate([result1.outputs, result2.outputs, result3.outputs], axis=0)
@@ -333,22 +382,23 @@ def test_delta_net_multi_step_generation() -> None:
     [(1, 4), (2, 8), (3, 7), (4, 16)],
 )
 def test_delta_net_output_invariant_to_chunk_size(chunk_size_a: int, chunk_size_b: int) -> None:
-    module_a = _make_delta_net(chunk_size=chunk_size_a)
-    module_b = _make_delta_net(chunk_size=chunk_size_b)
-    inputs = jax.random.normal(jax.random.PRNGKey(0), (12, module_a.model_dim))
+    module = _make_delta_net()
+    fpc_a = DeltaNetForwardPassConfig(chunk_size=chunk_size_a)
+    fpc_b = DeltaNetForwardPassConfig(chunk_size=chunk_size_b)
+    inputs = jax.random.normal(jax.random.PRNGKey(0), (12, module.model_dim))
 
-    result_a = module_a(inputs, positional_embeddings=None, return_updated_state=True)
-    result_b = module_b(inputs, positional_embeddings=None, return_updated_state=True)
+    result_a = module(inputs, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc_a)
+    result_b = module(inputs, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc_b)
 
     assert_close(result=result_a.outputs, reference=result_b.outputs, atol=1e-5)
-    assert result_a.state is not None
-    assert result_b.state is not None
+    assert result_a.state is not None and result_b.state is not None
     assert_close(result=result_a.state.ssm_state, reference=result_b.state.ssm_state, atol=1e-5)
 
 
 @pytest.mark.parametrize("seq_len", [128, 512])
 def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
-    module = _make_delta_net(chunk_size=64)
+    module = _make_delta_net()
+    fpc = DeltaNetForwardPassConfig(chunk_size=64)
     k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(0), 6)
 
     queries = jax.random.normal(k1, (seq_len, module.num_heads, module.head_dim))
@@ -359,10 +409,23 @@ def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
     initial_state = jax.random.normal(k6, (module.num_heads, module.value_head_dim, module.head_dim)) * 0.1
 
     out_seq, state_seq = module._recurrent_scan(
-        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+        queries,
+        keys,
+        values,
+        decay_factor,
+        beta,
+        initial_state,
+        seq_len,
     )
     out_chunk, state_chunk = module._chunked_scan(
-        queries, keys, values, decay_factor, beta, initial_state, seq_len,
+        queries,
+        keys,
+        values,
+        decay_factor,
+        beta,
+        initial_state,
+        seq_len,
+        fpc,
     )
 
     assert_close(result=out_chunk, reference=out_seq, atol=2e-3, fraction_of_allowed_violations=0.01)
@@ -373,7 +436,11 @@ def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
     ("seq_len", "chunk_size", "min_chunk_len"),
     [
         # seq_len < min_chunk_len: __call__ routes entirely to _scan
-        (3, 8, 4, ),
+        (
+            3,
+            8,
+            4,
+        ),
         (1, 4, 2),
         # Tail falls back to _scan: remainder=2 < min_chunk_len=3
         (10, 8, 3),
@@ -388,30 +455,15 @@ def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
     ],
 )
 def test_min_chunk_len_matches_sequential(seq_len: int, chunk_size: int, min_chunk_len: int) -> None:
-    from dataclasses import replace as dc_replace
-
-    module = _make_delta_net(chunk_size=chunk_size)
-    module_with_min = DeltaNetAttention(
-        dc_replace(module.config, min_chunk_len=min_chunk_len),
-        in_proj=module.in_proj,
-        conv=module.conv,
-        out_proj=module.out_proj,
-        norm=module.norm,
-        dt_bias=module.dt_bias,
-        a_log=module.a_log,
-        num_heads=module.num_heads,
-        num_groups=module.num_groups,
-        head_dim=module.head_dim,
-        value_head_dim=module.value_head_dim,
-        kernel_size=module.kernel_size,
-    )
+    module = _make_delta_net()
+    fpc_with_min = DeltaNetForwardPassConfig(chunk_size=chunk_size, min_chunk_len=min_chunk_len)
+    fpc_default = DeltaNetForwardPassConfig(chunk_size=chunk_size)
 
     inputs = jax.random.normal(jax.random.PRNGKey(0), (seq_len, module.model_dim))
 
-    result = module_with_min(inputs, positional_embeddings=None, return_updated_state=True)
-    reference = module(inputs, positional_embeddings=None, return_updated_state=True)
+    result = module(inputs, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc_with_min)
+    reference = module(inputs, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc_default)
 
     assert_close(result=result.outputs, reference=reference.outputs, atol=1e-5)
-    assert result.state is not None
-    assert reference.state is not None
+    assert result.state is not None and reference.state is not None
     assert_close(result=result.state.ssm_state, reference=reference.state.ssm_state, atol=1e-5)

--- a/tests/unit/test_delta_net.py
+++ b/tests/unit/test_delta_net.py
@@ -15,7 +15,8 @@ from lalamo.modules import (
     SeparableCausalConvConfig,
     UpcastMode,
 )
-from lalamo.modules.token_mixers.delta_net_attention import DeltaNetAttention, DeltaNetForwardPassConfig
+from lalamo.modules.token_mixers.common import MixerForwardPassConfig
+from lalamo.modules.token_mixers.delta_net_attention import DeltaNetAttention
 from lalamo.modules.torch_interop import torch_to_jax
 from tests.common import assert_close
 
@@ -181,7 +182,7 @@ def test_chunked_scan_matches_sequential(
     use_nonzero_state: bool,
 ) -> None:
     module = _make_delta_net()
-    fpc = DeltaNetForwardPassConfig(chunk_size=chunk_size)
+    fpc = MixerForwardPassConfig(chunk_size=chunk_size)
     k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(0), 6)
 
     queries = jax.random.normal(k1, (seq_len, module.num_heads, module.head_dim))
@@ -233,7 +234,7 @@ def test_delta_net_state_respects_length_without_padding(
     seed: int,
 ) -> None:
     module = _make_delta_net()
-    fpc = DeltaNetForwardPassConfig(chunk_size=4)
+    fpc = MixerForwardPassConfig(chunk_size=4)
     full_input = jax.random.normal(
         jax.random.PRNGKey(seed),
         (seqlen + padding, module.model_dim),
@@ -268,7 +269,7 @@ def test_delta_net_state_respects_length_without_padding(
 @pytest.mark.parametrize("seq_len", [8, 16])
 def test_delta_net_chunked_preserves_causality(seq_len: int) -> None:
     module = _make_delta_net()
-    fpc = DeltaNetForwardPassConfig(chunk_size=4)
+    fpc = MixerForwardPassConfig(chunk_size=4)
     inputs = jax.random.normal(jax.random.PRNGKey(123), (seq_len, module.model_dim))
 
     result_original = module(inputs, positional_embeddings=None, forward_pass_config=fpc)
@@ -287,7 +288,7 @@ def test_delta_net_chunked_preserves_causality(seq_len: int) -> None:
 
 def test_delta_net_chunked_with_gqa() -> None:
     module = _make_delta_net(num_heads=4, num_groups=2)
-    fpc = DeltaNetForwardPassConfig(chunk_size=4)
+    fpc = MixerForwardPassConfig(chunk_size=4)
     inputs = jax.random.normal(jax.random.PRNGKey(7), (12, module.model_dim))
 
     result = module(inputs, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc)
@@ -333,7 +334,7 @@ def test_delta_net_chunked_with_gqa() -> None:
 
 def test_delta_net_multi_step_generation() -> None:
     module = _make_delta_net()
-    fpc = DeltaNetForwardPassConfig(chunk_size=4)
+    fpc = MixerForwardPassConfig(chunk_size=4)
     k1, k2, k3 = jax.random.split(jax.random.PRNGKey(42), 3)
     chunk1 = jax.random.normal(k1, (6, module.model_dim))
     chunk2 = jax.random.normal(k2, (5, module.model_dim))
@@ -383,8 +384,8 @@ def test_delta_net_multi_step_generation() -> None:
 )
 def test_delta_net_output_invariant_to_chunk_size(chunk_size_a: int, chunk_size_b: int) -> None:
     module = _make_delta_net()
-    fpc_a = DeltaNetForwardPassConfig(chunk_size=chunk_size_a)
-    fpc_b = DeltaNetForwardPassConfig(chunk_size=chunk_size_b)
+    fpc_a = MixerForwardPassConfig(chunk_size=chunk_size_a)
+    fpc_b = MixerForwardPassConfig(chunk_size=chunk_size_b)
     inputs = jax.random.normal(jax.random.PRNGKey(0), (12, module.model_dim))
 
     result_a = module(inputs, positional_embeddings=None, return_updated_state=True, forward_pass_config=fpc_a)
@@ -398,7 +399,7 @@ def test_delta_net_output_invariant_to_chunk_size(chunk_size_a: int, chunk_size_
 @pytest.mark.parametrize("seq_len", [128, 512])
 def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
     module = _make_delta_net()
-    fpc = DeltaNetForwardPassConfig(chunk_size=64)
+    fpc = MixerForwardPassConfig(chunk_size=64)
     k1, k2, k3, k4, k5, k6 = jax.random.split(jax.random.PRNGKey(0), 6)
 
     queries = jax.random.normal(k1, (seq_len, module.num_heads, module.head_dim))
@@ -456,8 +457,8 @@ def test_chunked_scan_matches_sequential_large(seq_len: int) -> None:
 )
 def test_min_chunk_len_matches_sequential(seq_len: int, chunk_size: int, min_chunk_len: int) -> None:
     module = _make_delta_net()
-    fpc_with_min = DeltaNetForwardPassConfig(chunk_size=chunk_size, min_chunk_len=min_chunk_len)
-    fpc_default = DeltaNetForwardPassConfig(chunk_size=chunk_size)
+    fpc_with_min = MixerForwardPassConfig(chunk_size=chunk_size, min_chunk_len=min_chunk_len)
+    fpc_default = MixerForwardPassConfig(chunk_size=chunk_size)
 
     inputs = jax.random.normal(jax.random.PRNGKey(0), (seq_len, module.model_dim))
 


### PR DESCRIPTION
Implement a three-phase chunked scan algorithm that reduces
sequential depth from N to chunk_size + N/chunk_size:

Phase 1 (parallel via vmap): per-chunk scan computing local
outputs, propagation matrix M, and correction vectors.
Phase 2 (sequential over num_chunks): propagate actual initial
states across chunk boundaries.
Phase 3 (batched matmul): apply corrections from initial state.

- Default chunk_size=32 (8.3x speedup on H100 for 2048 tokens)
- min_chunk_len=16: short tails fall back to sequential _scan
- Sequences shorter than min_chunk_len skip chunking entirely
- Keep _scan as reference and fast path for short sequences

