### PR TITLE
native RHT lora import

### DIFF
--- a/lalamo/modules/linear.py
+++ b/lalamo/modules/linear.py
@@ -1148,23 +1148,15 @@ LinearConfig = FullPrecisionLinearConfig | GroupQuantizedLinearConfig | MLXQuant
 
 register_config_union(LinearConfig)
 
+_lc_types = {t.__name__: t for t in LinearConfig.__args__}
 
-def _structure_linear_config(
-    config: dict | None,
-    _: type[LinearConfig | None],
-) -> LinearConfig | None:
+
+def _structure_linear_config(config: dict | None, _: type) -> LinearConfig | None:
     if config is None:
         return None
     if config.get("type") == "RHTLinearWrapperConfig":
         config = config["inner_config"]
-    type_name = config["type"]
-    target_type = {
-        "FullPrecisionLinearConfig": FullPrecisionLinearConfig,
-        "GroupQuantizedLinearConfig": GroupQuantizedLinearConfig,
-        "MLXQuantizedLinearConfig": MLXQuantizedLinearConfig,
-        "QLoRALinearConfig": QLoRALinearConfig,
-    }[type_name]
-    return config_converter.structure({k: v for k, v in config.items() if k != "type"}, target_type)
+    return config_converter.structure({k: v for k, v in config.items() if k != "type"}, _lc_types[config["type"]])
 
 
 config_converter.register_structure_hook(LinearConfig, _structure_linear_config)

--- a/lalamo/modules/linear.py
+++ b/lalamo/modules/linear.py
@@ -951,38 +951,6 @@ class QLoRALinearConfig(GroupQuantizedLinearConfig):
         subkeys = jax.random.split(key, mixture_size)
         return eqx.filter_vmap(lambda k: self.random_init(input_dim, output_dims, has_biases, key=k))(subkeys)
 
-    def empty(
-        self,
-        input_dim: int,
-        output_dims: tuple[int, ...],
-        has_biases: bool,
-    ) -> LinearBase:
-        group_quantized_linear = super().empty(input_dim, output_dims, has_biases)
-        assert isinstance(group_quantized_linear, GroupQuantizedLinear)
-        hidden_lora_rank = len(output_dims) * self.lora_rank
-        lora_down_weights = dummy_array(
-            (input_dim, hidden_lora_rank),
-            dtype=self.activation_precision,
-        )
-        lora_up_weights = tuple(
-            dummy_array(
-                (self.lora_rank, output_dim),
-                dtype=self.activation_precision,
-            )
-            for output_dim in output_dims
-        )
-
-        return QLoRALinear(
-            config=self,
-            output_dims=output_dims,
-            weights=group_quantized_linear.weights,
-            scales=group_quantized_linear.scales,
-            biases=group_quantized_linear.biases,
-            zero_points=group_quantized_linear.zero_points,
-            lora_down_weights=lora_down_weights,
-            lora_up_weights=lora_up_weights,
-        )
-
     def _empty_general(
         self,
         leading_dims: tuple[int, ...],

--- a/lalamo/modules/linear.py
+++ b/lalamo/modules/linear.py
@@ -990,7 +990,7 @@ class QLoRALinearConfig(GroupQuantizedLinearConfig):
         output_dims: tuple[int, ...],
         has_biases: bool,
     ) -> LinearBase:
-        group_quantized_linear = super().empty(input_dim, output_dims, has_biases)
+        group_quantized_linear = super()._empty_general(leading_dims, input_dim, output_dims, has_biases)
         assert isinstance(group_quantized_linear, GroupQuantizedLinear)
 
         hidden_lora_rank = len(output_dims) * self.lora_rank

--- a/lalamo/modules/linear.py
+++ b/lalamo/modules/linear.py
@@ -18,6 +18,7 @@ from .common import (
     LalamoModule,
     ShardingOrder,
     TensorSharding,
+    config_converter,
     register_config_union,
     sharded_field,
 )
@@ -1131,18 +1132,40 @@ class QLoRALinear(GroupQuantizedLinearBase[QLoRALinearConfig]):
         self,
         weights: ParameterTree[Array],
     ) -> "QLoRALinear":
-        base = super().import_weights(weights)
-        weights = require_mapping(weights)
-        assert isinstance(weights["up_weights"], Sequence)
-        result = replace(
+        params = require_mapping(weights)
+        if "inner_linear" in params:
+            params = require_mapping(params["inner_linear"])
+        base = super().import_weights(params)
+        return replace(
             base,
-            lora_down_weights=weights["down_weights"],
-            lora_up_weights=tuple(up_weights for up_weights in weights["up_weights"]),
+            lora_down_weights=require_array(params["down_weights"]),
+            lora_up_weights=tuple(require_array(w) for w in params["up_weights"]),
         )
-        return result
 
 
 LinearConfig = FullPrecisionLinearConfig | GroupQuantizedLinearConfig | MLXQuantizedLinearConfig | QLoRALinearConfig
 
 
 register_config_union(LinearConfig)
+
+
+def _structure_linear_config(
+    config: dict | None,
+    _: type[LinearConfig | None],
+) -> LinearConfig | None:
+    if config is None:
+        return None
+    if config.get("type") == "RHTLinearWrapperConfig":
+        config = config["inner_config"]
+    type_name = config["type"]
+    target_type = {
+        "FullPrecisionLinearConfig": FullPrecisionLinearConfig,
+        "GroupQuantizedLinearConfig": GroupQuantizedLinearConfig,
+        "MLXQuantizedLinearConfig": MLXQuantizedLinearConfig,
+        "QLoRALinearConfig": QLoRALinearConfig,
+    }[type_name]
+    return config_converter.structure({k: v for k, v in config.items() if k != "type"}, target_type)
+
+
+config_converter.register_structure_hook(LinearConfig, _structure_linear_config)
+config_converter.register_structure_hook(LinearConfig | None, _structure_linear_config)


### PR DESCRIPTION
Loads QLoRA checkpoints from mirai-gpu's RHT (right-hand transposed) format without any monkeypatching.

- `QLoRALinear.import_weights` unwraps the `inner_linear` wrapper key present in RHT checkpoints
- `_structure_linear_config` hook strips `RHTLinearWrapperConfig` from the config JSON, resolving the inner type dynamically
- Fix `QLoRALinearConfig._empty_general` infinite recursion (was calling `super().empty()` which re-entered via polymorphic dispatch)
- Drop the redundant `QLoRALinearConfig.empty()` override — base class already dispatches `empty()` → `self._empty_general((), ...)`

Tested against `models/ungodly-lora-r16` on gup — model loads and runs.