### PR TITLE
Refactor: Add MixerForwardPassConfig to TokenMixerBase.__call__ signature

### DIFF
--- a/lalamo/modules/token_mixers/__init__.py
+++ b/lalamo/modules/token_mixers/__init__.py
@@ -1,7 +1,7 @@
 from lalamo.modules.common import register_config_union
 
 from .attention import Attention, AttentionConfig, AttentionResult
-from .common import TokenMixerBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 from .delta_net_attention import DeltaNetAttention, DeltaNetAttentionConfig, DeltaNetAttentionResult
 from .mamba import Mamba2, Mamba2Config, Mamba2Result
@@ -32,6 +32,7 @@ __all__ = [
     "Mamba2",
     "Mamba2Config",
     "Mamba2Result",
+    "MixerForwardPassConfig",
     "SSMStateLayer",
     "SeparableCausalConv",
     "SeparableCausalConvConfig",

--- a/lalamo/modules/token_mixers/attention.py
+++ b/lalamo/modules/token_mixers/attention.py
@@ -15,7 +15,7 @@ from lalamo.modules.normalization import Normalization, NormalizationConfig
 from lalamo.modules.rope import PositionalEmbeddings
 from lalamo.modules.utils import apply_soft_capping
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .state import DynamicKVCacheLayer, KVCacheLayer, StaticKVCacheLayer
 
 __all__ = [
@@ -377,6 +377,7 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
         state: KVCacheLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: ARG002, B008
     ) -> AttentionResult:
         queries, keys, values = vmap(self.qkv_projection, in_axes=0)(inputs)
         if self.gate_projection is not None:

--- a/lalamo/modules/token_mixers/common.py
+++ b/lalamo/modules/token_mixers/common.py
@@ -10,10 +10,16 @@ from lalamo.modules.rope import PositionalEmbeddings
 from .state.common import StateLayerBase
 
 __all__ = [
+    "MixerForwardPassConfig",
     "TokenMixerBase",
     "TokenMixerConfigBase",
     "TokenMixerResult",
 ]
+
+
+@dataclass(frozen=True)
+class MixerForwardPassConfig:
+    pass
 
 
 class TokenMixerResult[StateLayerT](NamedTuple):
@@ -63,6 +69,7 @@ class TokenMixerBase[ConfigT, StateLayerT: StateLayerBase](LalamoModule[ConfigT]
         state: StateLayerT | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: B008
     ) -> TokenMixerResult[StateLayerT]: ...
 
     @abstractmethod

--- a/lalamo/modules/token_mixers/delta_net_attention.py
+++ b/lalamo/modules/token_mixers/delta_net_attention.py
@@ -14,7 +14,7 @@ from lalamo.modules.normalization import Normalization, NormalizationConfig
 from lalamo.modules.rope import PositionalEmbeddings
 from lalamo.modules.token_mixers.state.ssm_state import SSMStateLayer
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 
 __all__ = [
@@ -244,6 +244,7 @@ class DeltaNetAttention(TokenMixerBase[DeltaNetAttentionConfig, SSMStateLayer]):
         state: SSMStateLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: ARG002, B008
     ) -> DeltaNetAttentionResult:
         if positional_embeddings is not None:
             raise ValueError("Positional embeddings are not supported for DeltaNetAttention.")

--- a/lalamo/modules/token_mixers/mamba.py
+++ b/lalamo/modules/token_mixers/mamba.py
@@ -15,7 +15,7 @@ from lalamo.modules.linear import LinearBase, LinearConfig
 from lalamo.modules.rope import PositionalEmbeddings
 from lalamo.modules.token_mixers.state.ssm_state import SSMStateLayer
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 
 __all__ = [
@@ -509,6 +509,7 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
         state: SSMStateLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: ARG002, B008
     ) -> Mamba2Result:
         if positional_embeddings is not None:
             raise ValueError("Positional embeddings are not supported for Mamba2.")

--- a/lalamo/modules/token_mixers/short_conv.py
+++ b/lalamo/modules/token_mixers/short_conv.py
@@ -10,7 +10,7 @@ from lalamo.modules.common import PositionalEmbeddingSelector
 from lalamo.modules.linear import LinearBase, LinearConfig
 from lalamo.modules.rope import PositionalEmbeddings
 
-from .common import TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
+from .common import MixerForwardPassConfig, TokenMixerBase, TokenMixerConfigBase, TokenMixerResult
 from .convolutions import SeparableCausalConv, SeparableCausalConvConfig
 from .state import ShortConvStateLayer
 
@@ -116,6 +116,7 @@ class ShortConv(TokenMixerBase[ShortConvConfig, ShortConvStateLayer]):
         state: ShortConvStateLayer | None = None,
         return_updated_state: bool = False,
         length_without_padding: Int[Array, ""] | int | None = None,
+        forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),  # noqa: ARG002, B008
     ) -> TokenMixerResult[ShortConvStateLayer]:
         if positional_embeddings is not None:
             raise ValueError("Positional embeddings are not supported for ShortConv.")


### PR DESCRIPTION
Introduce an empty frozen dataclass as an extension point for mixer-specific runtime parameters (e.g. chunk_size for DeltaNet). All mixer subclasses accept the new parameter.