### PR TITLE
Bump version to 0.6.13

### DIFF
--- a/lalamo/__init__.py
+++ b/lalamo/__init__.py
@@ -33,7 +33,7 @@ from lalamo.speculator import (
     SpeculatorTrainingEvent,
 )
 
-__version__ = "0.6.12"
+__version__ = "0.6.13"
 
 __all__ = [
     "AssistantMessage",


### PR DESCRIPTION
This PR bumps __version__ in lalamo/__init__.py to 0.6.13.