### PR TITLE
Add MLP zero-channel distill hook

### DIFF
--- a/lalamo/distill_runner.py
+++ b/lalamo/distill_runner.py
@@ -42,6 +42,7 @@ from lalamo.distillation import (
     materialize_trainable_module,
     summarize_distill_parameters,
 )
+from lalamo.mlp_zero_channels import MlpZeroChannelSpec, load_mlp_zero_channel_spec, zero_decoder_mlp_channels
 from lalamo.model_import import ModelMetadata
 from lalamo.models import LanguageModel, LanguageModelConfig
 from lalamo.modules import config_converter
@@ -134,6 +135,7 @@ class DistillConfig:
     seed: int = 0
     stochastic_rounding: bool = True
     save_checkpoints: bool = True
+    mlp_zero_channels_path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -374,6 +376,18 @@ def _build_lora_student_model(
     )
 
 
+def _materialize_student(
+    module: Decoder,
+    master_weights: object,
+    config: DistillTrainConfig,
+    zero_channel_spec: MlpZeroChannelSpec | None,
+) -> Decoder:
+    materialized = materialize_trainable_module(module, master_weights, config)
+    if zero_channel_spec is None:
+        return materialized
+    return zero_decoder_mlp_channels(materialized, zero_channel_spec)
+
+
 def _save_materialized_student(
     student_path: Path,
     output_path: Path,
@@ -561,9 +575,16 @@ def distill(
         raise ValueError("gradient_clip_norm must be positive when provided")
     if config.lora_scale <= 0:
         raise ValueError("lora_scale must be positive")
+    if config.mlp_zero_channels_path is not None and config.lora_rank is not None:
+        raise ValueError("MLP zero-channel induction requires lora_rank to be omitted")
+    if config.mlp_zero_channels_path is not None and config.resume_from is not None:
+        raise ValueError("MLP zero-channel induction does not support resume_from")
 
     sharding_config = ShardingConfig.build() if jax.device_count() > 1 else None
     device_batch_size = config.batch_size * jax.device_count()
+    zero_channel_spec = (
+        None if config.mlp_zero_channels_path is None else load_mlp_zero_channel_spec(config.mlp_zero_channels_path)
+    )
 
     if callbacks is not None:
         callbacks.started()
@@ -573,6 +594,8 @@ def distill(
         callbacks.loading_models()
     teacher_model = LanguageModelConfig.load_model(config.teacher_path)
     student_model = LanguageModelConfig.load_model(config.student_path)
+    if zero_channel_spec is not None:
+        student_model = replace(student_model, model=zero_decoder_mlp_channels(student_model.model, zero_channel_spec))
     if callbacks is not None:
         callbacks.finished_loading_models()
 
@@ -691,10 +714,11 @@ def distill(
 
     # Initial evaluation
     run_start = time.perf_counter()
-    initial_student = materialize_trainable_module(
+    initial_student = _materialize_student(
         student_model.model,
         optimizer_state.training_state.master_weights,
         distill_config,
+        zero_channel_spec,
     )
     initial_eval = _evaluate_with(
         config.training_mode,
@@ -775,10 +799,11 @@ def distill(
             eval_metrics: EvaluationMetrics | None = None
             if config.eval_every_steps > 0 and step % config.eval_every_steps == 0:
                 performed_periodic_evaluation = True
-                materialized_student = materialize_trainable_module(
+                materialized_student = _materialize_student(
                     student_model.model,
                     optimizer_state.training_state.master_weights,
                     distill_config,
+                    zero_channel_spec,
                 )
                 eval_metrics = _evaluate_with(
                     config.training_mode,
@@ -851,10 +876,11 @@ def distill(
             )
 
     # Final evaluation and export
-    final_student = materialize_trainable_module(
+    final_student = _materialize_student(
         student_model.model,
         optimizer_state.training_state.master_weights,
         distill_config,
+        zero_channel_spec,
     )
     final_eval = _evaluate_with(
         config.training_mode,
@@ -874,10 +900,11 @@ def distill(
         master_dtype=distill_config.master_dtype,
         compute_dtype=student_model.model.activation_precision,
     )
-    export_student = materialize_trainable_module(
+    export_student = _materialize_student(
         student_model.model,
         optimizer_state.training_state.master_weights,
         export_config,
+        zero_channel_spec,
     )
     if callbacks is not None:
         callbacks.saving_model()

--- a/lalamo/main.py
+++ b/lalamo/main.py
@@ -1128,6 +1128,10 @@ def distill_advanced(
         bool,
         Option(help="Persist latest and best checkpoints."),
     ] = _DISTILL_DEFAULTS["save_checkpoints"],
+    mlp_zero_channels_path: Annotated[
+        Path | None,
+        Option(help="JSON spec of dense MLP channels to hard-zero before distillation."),
+    ] = _DISTILL_DEFAULTS["mlp_zero_channels_path"],
 ) -> None:
     config = DistillConfig(
         teacher_path=teacher_path,
@@ -1156,6 +1160,7 @@ def distill_advanced(
         seed=seed,
         stochastic_rounding=stochastic_rounding,
         save_checkpoints=save_checkpoints,
+        mlp_zero_channels_path=mlp_zero_channels_path,
     )
     _distill(config, callbacks=CliDistillCallbacks(config))
 

--- a/lalamo/mlp_zero_channels.py
+++ b/lalamo/mlp_zero_channels.py
@@ -1,0 +1,110 @@
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import jax.numpy as jnp
+from cattrs import Converter
+from jaxtyping import Array
+
+from lalamo.modules.decoder import Decoder
+from lalamo.modules.linear import FullPrecisionLinear
+from lalamo.modules.mlp import DenseMLP
+
+__all__ = [
+    "MlpZeroChannelLayer",
+    "MlpZeroChannelSpec",
+    "load_mlp_zero_channel_spec",
+    "zero_decoder_mlp_channels",
+    "zero_mlp_channels",
+]
+
+
+_CONVERTER = Converter()
+
+
+@dataclass(frozen=True)
+class MlpZeroChannelLayer:
+    layer_index: int
+    channels: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class MlpZeroChannelSpec:
+    layers: tuple[MlpZeroChannelLayer, ...]
+
+
+def load_mlp_zero_channel_spec(path: Path | str) -> MlpZeroChannelSpec:
+    with Path(path).open() as spec_file:
+        return _validate_spec(_CONVERTER.structure(json.load(spec_file), MlpZeroChannelSpec))
+
+
+def zero_decoder_mlp_channels(decoder: Decoder, spec: MlpZeroChannelSpec) -> Decoder:
+    layers = list(decoder.transformer.layers)
+    for layer_spec in spec.layers:
+        if layer_spec.layer_index >= len(layers):
+            raise ValueError(f"Layer index {layer_spec.layer_index} exceeds decoder depth {len(layers)}")
+        mlp = layers[layer_spec.layer_index].mlp
+        if not isinstance(mlp, DenseMLP):
+            raise TypeError(f"Layer {layer_spec.layer_index} MLP is {type(mlp).__name__}, expected DenseMLP")
+        layers[layer_spec.layer_index] = replace(
+            layers[layer_spec.layer_index],
+            mlp=zero_mlp_channels(mlp, layer_spec.channels),
+        )
+    return replace(decoder, transformer=replace(decoder.transformer, layers=tuple(layers)))
+
+
+def zero_mlp_channels(mlp: DenseMLP, channels: tuple[int, ...]) -> DenseMLP:
+    up_projection = _require_full_precision(mlp.up_projection, "up_projection")
+    down_projection = _require_full_precision(mlp.down_projection, "down_projection")
+    if mlp.mixture_size is not None:
+        raise ValueError("MLP zero-channel induction requires a non-mixture DenseMLP")
+
+    channels = _normalize_channels(channels, mlp.hidden_dim)
+    hidden_dim = mlp.hidden_dim
+    up_rows = jnp.asarray(channels + tuple(hidden_dim + channel for channel in channels), dtype=jnp.int32)
+    down_columns = jnp.asarray(channels, dtype=jnp.int32)
+
+    zeroed_up = replace(
+        up_projection,
+        weights=up_projection.weights.at[up_rows, :].set(0),
+        biases=_zero_vector_indices(up_projection.biases, up_rows),
+    )
+    zeroed_down = replace(
+        down_projection,
+        weights=down_projection.weights.at[:, down_columns].set(0),
+    )
+    return replace(mlp, up_projection=zeroed_up, down_projection=zeroed_down)
+
+
+def _validate_spec(spec: MlpZeroChannelSpec) -> MlpZeroChannelSpec:
+    if not spec.layers:
+        raise ValueError("MLP zero-channel spec must contain at least one layer")
+    for layer in spec.layers:
+        if layer.layer_index < 0:
+            raise ValueError("MLP zero-channel layer indices must be non-negative")
+        if not layer.channels:
+            raise ValueError("MLP zero-channel layers must contain at least one channel")
+    return spec
+
+
+def _normalize_channels(channels: tuple[int, ...], hidden_dim: int) -> tuple[int, ...]:
+    if not channels:
+        raise ValueError("MLP zero-channel list must contain at least one channel")
+    result = tuple(sorted(channels))
+    if len(set(result)) != len(result):
+        raise ValueError(f"Duplicate MLP zero-channel index in {channels}")
+    if result[0] < 0 or result[-1] >= hidden_dim:
+        raise ValueError(f"MLP zero-channel indices {channels} exceed hidden dimension {hidden_dim}")
+    return result
+
+
+def _require_full_precision(linear: object, name: str) -> FullPrecisionLinear:
+    if not isinstance(linear, FullPrecisionLinear):
+        raise TypeError(f"MLP zero-channel induction requires full precision {name}, got {type(linear).__name__}")
+    return linear
+
+
+def _zero_vector_indices(values: Array | None, indices: Array) -> Array | None:
+    if values is None:
+        return None
+    return values.at[indices].set(0)

--- a/tests/unit/test_distillation.py
+++ b/tests/unit/test_distillation.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -20,15 +22,26 @@ from lalamo.distillation import (
     make_trace_distill_batch,
     materialize_trainable_module,
 )
+from lalamo.mlp_zero_channels import (
+    MlpZeroChannelLayer,
+    MlpZeroChannelSpec,
+    load_mlp_zero_channel_spec,
+    zero_decoder_mlp_channels,
+    zero_mlp_channels,
+)
 from lalamo.model_import.model_configs.huggingface.llama import HFLlamaConfig
+from lalamo.modules.activations import SiLU
 from lalamo.modules.common import config_converter, field, iter_parameter_leaves
 from lalamo.modules.decoder import Decoder
 from lalamo.modules.linear import (
+    FullPrecisionLinear,
+    FullPrecisionLinearConfig,
     GroupQuantizedLinearConfig,
     LinearConfig,
     MLXQuantizedLinearConfig,
     QLoRALinearConfig,
 )
+from lalamo.modules.mlp import DenseMLP, DenseMLPConfig
 from lalamo.quantization import QuantizationMode
 
 requires_muon_dimension_numbers = pytest.mark.skipif(
@@ -189,6 +202,104 @@ def _make_tiny_llama_decoder(*, key: jax.Array) -> Decoder:
         metadata_dict={},
     )
     return decoder_config.random_init(key=key)
+
+
+def test_load_mlp_zero_channel_spec(tmp_path: Path) -> None:
+    spec_path = tmp_path / "mlp-zero.json"
+    spec_path.write_text('{"layers": [{"layer_index": 0, "channels": [5, 2]}]}')
+
+    spec = load_mlp_zero_channel_spec(spec_path)
+
+    assert spec == MlpZeroChannelSpec(layers=(MlpZeroChannelLayer(layer_index=0, channels=(5, 2)),))
+
+
+def test_zero_decoder_mlp_channels_zeroes_swiglu_channel_weights() -> None:
+    decoder = _make_tiny_llama_decoder(key=jax.random.key(47))
+    zeroed = zero_decoder_mlp_channels(
+        decoder,
+        MlpZeroChannelSpec(layers=(MlpZeroChannelLayer(layer_index=0, channels=(2, 5)),)),
+    )
+
+    mlp = zeroed.transformer.layers[0].mlp
+    assert isinstance(mlp, DenseMLP)
+    assert isinstance(mlp.up_projection, FullPrecisionLinear)
+    assert isinstance(mlp.down_projection, FullPrecisionLinear)
+
+    up_rows = jnp.asarray((2, 5, mlp.hidden_dim + 2, mlp.hidden_dim + 5), dtype=jnp.int32)
+    down_columns = jnp.asarray((2, 5), dtype=jnp.int32)
+
+    assert jnp.array_equal(
+        mlp.up_projection.weights[up_rows, :],
+        jnp.zeros_like(mlp.up_projection.weights[up_rows, :]),
+    )
+    assert jnp.array_equal(
+        mlp.down_projection.weights[:, down_columns],
+        jnp.zeros_like(mlp.down_projection.weights[:, down_columns]),
+    )
+
+
+def test_zero_mlp_channels_zeroes_up_and_gate_biases() -> None:
+    mlp = DenseMLPConfig(
+        linear_config=FullPrecisionLinearConfig(precision=jnp.float32),
+        activation=SiLU(),
+        has_up_biases=True,
+        has_down_biases=True,
+        gate_clipping=None,
+        up_clipping=None,
+    ).random_init(model_dim=4, hidden_dim=6, key=jax.random.key(51))
+
+    zeroed = zero_mlp_channels(mlp, (1,))
+
+    assert isinstance(zeroed.up_projection, FullPrecisionLinear)
+    assert zeroed.up_projection.biases is not None
+    assert zeroed.down_projection.biases is not None
+    assert jnp.array_equal(
+        zeroed.up_projection.biases[jnp.asarray((1, 7))],
+        jnp.zeros((2,), dtype=jnp.float32),
+    )
+    assert jnp.array_equal(zeroed.down_projection.biases, mlp.down_projection.biases)
+
+
+def test_zero_decoder_mlp_channels_are_absorbing_under_distillation() -> None:
+    teacher = _make_tiny_llama_decoder(key=jax.random.key(53))
+    student = zero_decoder_mlp_channels(
+        teacher,
+        MlpZeroChannelSpec(layers=(MlpZeroChannelLayer(layer_index=0, channels=(2,)),)),
+    )
+    batch = DistillBatch(
+        token_ids=jnp.array([[1, 2, 3, 4, 5, 6]], dtype=jnp.int32),
+        lengths_without_padding=jnp.array([6], dtype=jnp.int32),
+    )
+    config = DistillTrainConfig(master_dtype=jnp.float32, compute_dtype=jnp.float32)
+    training_state = initialize_distill_training_state(student, config)
+    optimizer_state = _make_optimizer_state(training_state, optax.sgd(0.1))
+
+    grads, _ = compute_distill_step_gradients(
+        optimizer_state.training_state,
+        student,
+        teacher,
+        batch,
+        config,
+        QuantizationMode.UINT4,
+        stochastic_rounding=True,
+        quantization_key=jax.random.key(54),
+    )
+    optimizer_state = apply_distill_gradients(optimizer_state, optax.sgd(0.1), grads)
+    trained = materialize_trainable_module(student, optimizer_state.training_state.master_weights, config)
+    mlp = trained.transformer.layers[0].mlp
+    assert isinstance(mlp, DenseMLP)
+    assert isinstance(mlp.up_projection, FullPrecisionLinear)
+    assert isinstance(mlp.down_projection, FullPrecisionLinear)
+
+    up_rows = jnp.asarray((2, mlp.hidden_dim + 2), dtype=jnp.int32)
+    assert jnp.array_equal(
+        mlp.up_projection.weights[up_rows, :],
+        jnp.zeros_like(mlp.up_projection.weights[up_rows, :]),
+    )
+    assert jnp.array_equal(
+        mlp.down_projection.weights[:, 2],
+        jnp.zeros_like(mlp.down_projection.weights[:, 2]),
+    )
 
 
 def test_compute_distill_batch_metrics_matches_teacher_logits() -> None:


### PR DESCRIPTION
## What changed

Adds a small lalamo-only hook for inducing structural MLP zeros before distillation:

- Adds `MlpZeroChannelSpec` JSON loading and `zero_decoder_mlp_channels` helpers.
- Hard-zeros selected dense MLP channels across `up`, `gate`, and `down` paths.
- Applies the zero spec before distillation and again when materializing eval/export students.
- Exposes the hook through `lalamo distill-advanced --mlp-zero-channels-path`.

## Why

This keeps the MLP compaction path separate from the quant-distill PR while giving lalamo a direct way to create the structural-zero artifact that uzu's exact compactor can later package as smaller dense tensors.

## Validation

- `uv run pytest -m fast tests/unit/test_distillation.py -k 'mlp_zero_channel or zero_decoder_mlp or zero_mlp_channels' -q`
- `uv run ruff check lalamo/mlp_zero_channels.py lalamo/distill_runner.py tests/unit/test_distillation.py --select I,F,UP,B,ANN,RUF --ignore F722`
- `uv run ruff check lalamo/main.py --select F,UP,B,ANN,RUF --ignore F722`
- `uv run lalamo distill-advanced --help`

Note: full `tests/unit/test_distillation.py` is already blocked on the base branch by existing distill-gradient tests that do not pass the required `stochastic_rounding` / `quantization_key` kwargs.
