### PR TITLE
Explore W4A16 packed prefill GEMM routes

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark entrypoints."""

--- a/benchmarks/bench_w4a16_prefill.py
+++ b/benchmarks/bench_w4a16_prefill.py
@@ -1,0 +1,153 @@
+import argparse
+import time
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+
+from lalamo.compressed.awq import AWQMatrixForInference, AWQSpec, _awq_unpack_master_weights
+from lalamo.compressed.cute_w4a16_dot import _call_awq, _call_mlx, awq_w4a16_dot, mlx_w4a16_dot
+from lalamo.compressed.mlx import MLXMatrixForInference, MLXSpec, _mlx_unpack_master_weights
+from lalamo.weight_matrix import CompressionImplementation
+
+type Benchmark = tuple[Callable[..., jax.Array], tuple[jax.Array, ...]]
+
+
+def _time_us(fn: Callable[..., jax.Array], args: tuple[jax.Array, ...], *, warmups: int, iters: int) -> float:
+    fn = jax.jit(fn)
+    for _ in range(warmups):
+        fn(*args).block_until_ready()
+
+    start = time.perf_counter()
+    for _ in range(iters):
+        fn(*args).block_until_ready()
+    return (time.perf_counter() - start) * 1_000_000 / iters
+
+
+def _mlx_packed(
+    vectors: jax.Array,
+    packed_weights: jax.Array,
+    scales: jax.Array,
+    biases: jax.Array,
+    weights: jax.Array,
+) -> jax.Array:
+    return jax.vmap(lambda vector: mlx_w4a16_dot(vector, packed_weights, scales, biases, weights))(vectors)
+
+
+def _mlx_materialize(
+    vectors: jax.Array,
+    packed_weights: jax.Array,
+    scales: jax.Array,
+    biases: jax.Array,
+) -> jax.Array:
+    weights = _mlx_unpack_master_weights(packed_weights, scales, biases, 32, 4).astype(vectors.dtype)
+    return jnp.einsum("bc,rc->br", vectors, weights)
+
+
+def _awq_packed(
+    vectors: jax.Array,
+    packed_weights: jax.Array,
+    scales: jax.Array,
+    packed_zero_points: jax.Array,
+    weights: jax.Array,
+) -> jax.Array:
+    return jax.vmap(lambda vector: awq_w4a16_dot(vector, packed_weights, scales, packed_zero_points, weights))(vectors)
+
+
+def _awq_materialize(
+    vectors: jax.Array,
+    packed_weights: jax.Array,
+    scales: jax.Array,
+    packed_zero_points: jax.Array,
+) -> jax.Array:
+    weights = _awq_unpack_master_weights(packed_weights, scales, packed_zero_points, 32, 4).astype(vectors.dtype)
+    return jnp.einsum("bc,rc->br", vectors, weights)
+
+
+def _dense(vectors: jax.Array, weights: jax.Array) -> jax.Array:
+    return jnp.einsum("bc,rc->br", vectors, weights)
+
+
+def _mlx_paths(matrix: MLXMatrixForInference, vectors: jax.Array) -> dict[str, Benchmark]:
+    packed_weights = matrix.packed_weights
+    scales = matrix.scales.astype(vectors.dtype)
+    biases = matrix.biases.astype(vectors.dtype)
+    dense_weights = matrix.weights.astype(vectors.dtype)
+
+    return {
+        "direct_cute": (_call_mlx, (vectors, packed_weights, scales, biases)),
+        "packed_cute": (_mlx_packed, (vectors, packed_weights, scales, biases, dense_weights)),
+        "cached_dense": (_dense, (vectors, dense_weights)),
+        "materialize_dense": (_mlx_materialize, (vectors, packed_weights, scales, biases)),
+    }
+
+
+def _awq_paths(matrix: AWQMatrixForInference, vectors: jax.Array) -> dict[str, Benchmark]:
+    packed_weights = matrix.packed_weights
+    scales = matrix.scales.astype(vectors.dtype)
+    packed_zero_points = matrix.packed_zero_points
+    dense_weights = matrix.weights.astype(vectors.dtype)
+
+    return {
+        "direct_cute": (_call_awq, (vectors, packed_weights, scales, packed_zero_points)),
+        "packed_cute": (_awq_packed, (vectors, packed_weights, scales, packed_zero_points, dense_weights)),
+        "cached_dense": (_dense, (vectors, dense_weights)),
+        "materialize_dense": (_awq_materialize, (vectors, packed_weights, scales, packed_zero_points)),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", type=int, default=6144)
+    parser.add_argument("--cols", type=int, default=2048)
+    parser.add_argument("--group-size", type=int, default=32)
+    parser.add_argument("--batches", type=int, nargs="+", default=[1, 2, 4, 8, 16, 32, 64])
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--warmups", type=int, default=20)
+    parser.add_argument("--dtype", choices=["float16", "bfloat16"], default="float16")
+    args = parser.parse_args()
+
+    assert args.group_size == 32
+    assert args.cols % args.group_size == 0
+    dtype = jnp.float16 if args.dtype == "float16" else jnp.bfloat16
+
+    key = jax.random.key(0)
+    weight_key, vector_key = jax.random.split(key)
+    weights = jax.random.normal(weight_key, (args.rows, args.cols), dtype=jnp.float32)
+    max_batch = max(args.batches)
+    vectors = jax.random.normal(vector_key, (max_batch, args.cols), dtype=dtype)
+
+    mlx_matrix = MLXSpec(bits=4, group_size=args.group_size).compress(
+        weights,
+        implementation=CompressionImplementation.INFERENCE,
+    )
+    awq_matrix = AWQSpec(bits=4, group_size=args.group_size).compress(
+        weights,
+        implementation=CompressionImplementation.INFERENCE,
+    )
+    assert isinstance(mlx_matrix, MLXMatrixForInference)
+    assert isinstance(awq_matrix, AWQMatrixForInference)
+
+    print(f"backend={jax.default_backend()} shape={args.rows}x{args.cols} group={args.group_size} dtype={args.dtype}")
+    print("format,batch,direct_cute_us,packed_cute_us,cached_dense_us,materialize_dense_us,best_us,best_path")
+    for batch in args.batches:
+        batch_vectors = vectors[:batch]
+        for name, matrix, path_builder in (
+            ("mlx", mlx_matrix, _mlx_paths),
+            ("awq", awq_matrix, _awq_paths),
+        ):
+            paths = path_builder(matrix, batch_vectors)
+            times = {
+                path_name: _time_us(path, path_args, warmups=args.warmups, iters=args.iters)
+                for path_name, (path, path_args) in paths.items()
+            }
+            best_path = min(times, key=times.__getitem__)
+            print(
+                f"{name},{batch},{times['direct_cute']:.2f},{times['packed_cute']:.2f},{times['cached_dense']:.2f},"
+                f"{times['materialize_dense']:.2f},{times[best_path]:.2f},{best_path}",
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_w4a16_prefill.py
+++ b/benchmarks/bench_w4a16_prefill.py
@@ -132,11 +132,10 @@ def main() -> None:
     print("format,batch,direct_cute_us,packed_cute_us,cached_dense_us,materialize_dense_us,best_us,best_path")
     for batch in args.batches:
         batch_vectors = vectors[:batch]
-        for name, matrix, path_builder in (
-            ("mlx", mlx_matrix, _mlx_paths),
-            ("awq", awq_matrix, _awq_paths),
+        for name, paths in (
+            ("mlx", _mlx_paths(mlx_matrix, batch_vectors)),
+            ("awq", _awq_paths(awq_matrix, batch_vectors)),
         ):
-            paths = path_builder(matrix, batch_vectors)
             times = {
                 path_name: _time_us(path, path_args, warmups=args.warmups, iters=args.iters)
                 for path_name, (path, path_args) in paths.items()

--- a/benchmarks/bench_w4a16_prefill.py
+++ b/benchmarks/bench_w4a16_prefill.py
@@ -24,7 +24,7 @@ def _time_us(fn: Callable[..., jax.Array], args: tuple[jax.Array, ...], *, warmu
     return (time.perf_counter() - start) * 1_000_000 / iters
 
 
-def _mlx_packed(
+def _mlx_routed(
     vectors: jax.Array,
     packed_weights: jax.Array,
     scales: jax.Array,
@@ -44,7 +44,7 @@ def _mlx_materialize(
     return jnp.einsum("bc,rc->br", vectors, weights)
 
 
-def _awq_packed(
+def _awq_routed(
     vectors: jax.Array,
     packed_weights: jax.Array,
     scales: jax.Array,
@@ -76,7 +76,7 @@ def _mlx_paths(matrix: MLXMatrixForInference, vectors: jax.Array) -> dict[str, B
 
     return {
         "direct_cute": (_call_mlx, (vectors, packed_weights, scales, biases)),
-        "packed_cute": (_mlx_packed, (vectors, packed_weights, scales, biases, dense_weights)),
+        "routed_public": (_mlx_routed, (vectors, packed_weights, scales, biases, dense_weights)),
         "cached_dense": (_dense, (vectors, dense_weights)),
         "materialize_dense": (_mlx_materialize, (vectors, packed_weights, scales, biases)),
     }
@@ -90,7 +90,7 @@ def _awq_paths(matrix: AWQMatrixForInference, vectors: jax.Array) -> dict[str, B
 
     return {
         "direct_cute": (_call_awq, (vectors, packed_weights, scales, packed_zero_points)),
-        "packed_cute": (_awq_packed, (vectors, packed_weights, scales, packed_zero_points, dense_weights)),
+        "routed_public": (_awq_routed, (vectors, packed_weights, scales, packed_zero_points, dense_weights)),
         "cached_dense": (_dense, (vectors, dense_weights)),
         "materialize_dense": (_awq_materialize, (vectors, packed_weights, scales, packed_zero_points)),
     }
@@ -129,7 +129,7 @@ def main() -> None:
     assert isinstance(awq_matrix, AWQMatrixForInference)
 
     print(f"backend={jax.default_backend()} shape={args.rows}x{args.cols} group={args.group_size} dtype={args.dtype}")
-    print("format,batch,direct_cute_us,packed_cute_us,cached_dense_us,materialize_dense_us,best_us,best_path")
+    print("format,batch,direct_cute_us,routed_public_us,cached_dense_us,materialize_dense_us,best_us,best_path")
     for batch in args.batches:
         batch_vectors = vectors[:batch]
         for name, paths in (
@@ -142,7 +142,7 @@ def main() -> None:
             }
             best_path = min(times, key=times.__getitem__)
             print(
-                f"{name},{batch},{times['direct_cute']:.2f},{times['packed_cute']:.2f},{times['cached_dense']:.2f},"
+                f"{name},{batch},{times['direct_cute']:.2f},{times['routed_public']:.2f},{times['cached_dense']:.2f},"
                 f"{times['materialize_dense']:.2f},{times[best_path]:.2f},{best_path}",
                 flush=True,
             )

--- a/lalamo/compressed/cute_w4a16_dot.py
+++ b/lalamo/compressed/cute_w4a16_dot.py
@@ -19,7 +19,7 @@ from .cute_w4a16_contract import (
 )
 
 PACKED_DECODE_MIN_ROWS = 10240
-PACKED_PAIR_PREFILL_MAX_ROWS = 4096
+PACKED_PAIR_PREFILL_MIN_ROWS = 12288
 
 
 @cute.kernel
@@ -196,7 +196,9 @@ def _use_dense_matmul(vectors: Array, packed_weights: Array) -> bool:
     rows = packed_weights.shape[0]
     if batch == 1:
         return rows < PACKED_DECODE_MIN_ROWS
-    return batch != 2 or rows > PACKED_PAIR_PREFILL_MAX_ROWS
+    if batch == 2:
+        return rows < PACKED_PAIR_PREFILL_MIN_ROWS
+    return True
 
 
 def mlx_w4a16_matmul(

--- a/lalamo/compressed/hybrid.py
+++ b/lalamo/compressed/hybrid.py
@@ -284,7 +284,7 @@ def _uses_final_cache(output_dim: int, matrix: HybridMatrix) -> bool:
 
 
 class HybridMatrixForInference(HybridMatrix):
-    weights: FullPrecisionMatrix = field(trainable=False)
+    final_weights: FullPrecisionMatrix = field(trainable=False)
 
     @classmethod
     def from_hybrid(cls, matrix: HybridMatrix) -> "HybridMatrixForInference":
@@ -293,7 +293,7 @@ class HybridMatrixForInference(HybridMatrix):
             quantized=matrix.quantized,
             adapter=matrix.adapter,
             incoherence_signs=matrix.incoherence_signs,
-            weights=_full_precision_cache(matrix),
+            final_weights=_full_precision_cache(matrix),
         )
 
     def _without_cache(self) -> HybridMatrix:
@@ -309,28 +309,28 @@ class HybridMatrixForInference(HybridMatrix):
 
     def load_exported(
         self,
-        expored_data: ExportResults,
+        exported_data: ExportResults,
         allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> "HybridMatrixForInference":
         loaded = self._without_cache().load_exported(
-            expored_data,
+            exported_data,
             allow_dtype_cast=allow_dtype_cast,
             prefix=prefix,
         )
         return HybridMatrixForInference.from_hybrid(loaded)
 
     def to_full_precision(self) -> FullPrecisionMatrix:
-        return self.weights
+        return self.final_weights
 
     @property
     def shape(self) -> tuple[int, ...]:
-        return self.weights.shape
+        return self.final_weights.shape
 
     @property
     def dtype(self) -> DTypeLike:
-        return self.weights.dtype
+        return self.final_weights.dtype
 
     def astype(self, dtype: DTypeLike) -> "HybridMatrixForInference":
         return HybridMatrixForInference(
@@ -338,12 +338,12 @@ class HybridMatrixForInference(HybridMatrix):
             quantized=self.quantized.astype(dtype),
             adapter=self.adapter.astype(dtype) if self.adapter is not None else None,
             incoherence_signs=self.incoherence_signs,
-            weights=self.weights.astype(dtype),
+            final_weights=self.final_weights.astype(dtype),
         )
 
     @use_out_sharding((None, None))
     def decompress(self) -> Float[Array, "... out_channels in_channels"]:
-        return self.weights.decompress()
+        return self.final_weights.decompress()
 
     def switch_implementation(self, implementation: CompressionImplementation) -> HybridMatrix:
         if implementation == CompressionImplementation.INFERENCE:
@@ -358,7 +358,7 @@ class HybridMatrixForInference(HybridMatrix):
         forward_pass_config: MatmulConfig = MatmulConfig(),
         transposed: bool = False,
     ) -> Float[Array, "... channels"]:
-        return self.weights.dot(
+        return self.final_weights.dot(
             vector,
             keychain=keychain,
             forward_pass_config=forward_pass_config,

--- a/lalamo/compressed/hybrid.py
+++ b/lalamo/compressed/hybrid.py
@@ -7,8 +7,10 @@ import jax.numpy as jnp
 from jaxtyping import Array, DTypeLike, Float, Int, Key
 
 from lalamo.compressed.hadamard import hadamard_transform
+from lalamo.exportable import ExportResults
 from lalamo.module import Keychain, field
-from lalamo.utils.dummy_array import supports_dummy_arrays
+from lalamo.utils.dummy_array import contains_dummy_arrays, dummy_array, supports_dummy_arrays
+from lalamo.utils.parameter_path import ParameterPath
 from lalamo.utils.sharding import use_out_sharding
 from lalamo.weight_matrix import (
     CompressionImplementation,
@@ -25,6 +27,8 @@ __all__ = [
     "HybridMatrix",
     "HybridSpec",
 ]
+
+_HYBRID_FINAL_CACHE_MIN_OUTPUT_DIM = 10240
 
 
 def _random_incoherence_signs(
@@ -161,12 +165,15 @@ class HybridSpec(WeightMatrixSpec):
         else:
             adapter = None
 
-        return HybridMatrix(
+        matrix = HybridMatrix(
             spec=self,
             quantized=quantized,
             adapter=adapter,
             incoherence_signs=incoherence_signs,
         )
+        if implementation == CompressionImplementation.INFERENCE and _uses_final_cache(output_dim, matrix):
+            return HybridMatrixForInference.from_hybrid(matrix)
+        return matrix
 
 
 class HybridMatrix(WeightMatrix[HybridSpec]):
@@ -213,12 +220,15 @@ class HybridMatrix(WeightMatrix[HybridSpec]):
         adapter = self.adapter
         if adapter is not None:
             adapter = adapter.switch_implementation(implementation)
-        return HybridMatrix(
+        matrix = HybridMatrix(
             spec=self.spec,
             quantized=quantized,
             adapter=adapter,
             incoherence_signs=self.incoherence_signs,
         )
+        if implementation == CompressionImplementation.INFERENCE and _uses_final_cache(matrix.shape[-2], matrix):
+            return HybridMatrixForInference.from_hybrid(matrix)
+        return matrix
 
     def dot(
         self,
@@ -258,3 +268,99 @@ class HybridMatrix(WeightMatrix[HybridSpec]):
                 transposed=transposed,
             )
         return result
+
+
+def _full_precision_cache(matrix: HybridMatrix) -> FullPrecisionMatrix:
+    if contains_dummy_arrays(matrix):
+        weights = dummy_array(matrix.shape, matrix.dtype)
+    else:
+        weights = matrix.decompress()
+    return FullPrecisionSpec(layout=Layout.OUTPUT_INPUT).compress(weights)
+
+
+def _uses_final_cache(output_dim: int, matrix: HybridMatrix) -> bool:
+    has_wrapper_work = matrix.incoherence_signs is not None or matrix.adapter is not None
+    return has_wrapper_work and output_dim >= _HYBRID_FINAL_CACHE_MIN_OUTPUT_DIM
+
+
+class HybridMatrixForInference(HybridMatrix):
+    weights: FullPrecisionMatrix = field(trainable=False)
+
+    @classmethod
+    def from_hybrid(cls, matrix: HybridMatrix) -> "HybridMatrixForInference":
+        return cls(
+            spec=matrix.spec,
+            quantized=matrix.quantized,
+            adapter=matrix.adapter,
+            incoherence_signs=matrix.incoherence_signs,
+            weights=_full_precision_cache(matrix),
+        )
+
+    def _without_cache(self) -> HybridMatrix:
+        return HybridMatrix(
+            spec=self.spec,
+            quantized=self.quantized,
+            adapter=self.adapter,
+            incoherence_signs=self.incoherence_signs,
+        )
+
+    def export(self) -> ExportResults:
+        return self._without_cache().export()
+
+    def load_exported(
+        self,
+        expored_data: ExportResults,
+        allow_dtype_cast: bool = False,
+        *,
+        prefix: ParameterPath | None = None,
+    ) -> "HybridMatrixForInference":
+        loaded = self._without_cache().load_exported(
+            expored_data,
+            allow_dtype_cast=allow_dtype_cast,
+            prefix=prefix,
+        )
+        return HybridMatrixForInference.from_hybrid(loaded)
+
+    def to_full_precision(self) -> FullPrecisionMatrix:
+        return self.weights
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.weights.shape
+
+    @property
+    def dtype(self) -> DTypeLike:
+        return self.weights.dtype
+
+    def astype(self, dtype: DTypeLike) -> "HybridMatrixForInference":
+        return HybridMatrixForInference(
+            spec=self.spec,
+            quantized=self.quantized.astype(dtype),
+            adapter=self.adapter.astype(dtype) if self.adapter is not None else None,
+            incoherence_signs=self.incoherence_signs,
+            weights=self.weights.astype(dtype),
+        )
+
+    @use_out_sharding((None, None))
+    def decompress(self) -> Float[Array, "... out_channels in_channels"]:
+        return self.weights.decompress()
+
+    def switch_implementation(self, implementation: CompressionImplementation) -> HybridMatrix:
+        if implementation == CompressionImplementation.INFERENCE:
+            return self
+        return self._without_cache().switch_implementation(implementation)
+
+    def dot(
+        self,
+        vector: Float[Array, " channels"],
+        *,
+        keychain: Keychain,
+        forward_pass_config: MatmulConfig = MatmulConfig(),
+        transposed: bool = False,
+    ) -> Float[Array, "... channels"]:
+        return self.weights.dot(
+            vector,
+            keychain=keychain,
+            forward_pass_config=forward_pass_config,
+            transposed=transposed,
+        )


### PR DESCRIPTION
## Summary

Experimental branch on top of the clean CuTe W4A16 dot PR. This keeps the merge PR small while we test the next speed fronts:

- correct the W4A16 prefill route cutoff using compiled-loop H100 timings, not misleading Python-dispatch timings
- add a focused W4A16 prefill route benchmark with separate `direct_cute`, `routed_public`, `cached_dense`, and `materialize_dense` columns
- add a derived final-basis dense cache for large Hybrid/RHT inference matrices where wrapper work is expensive

## What Actually Improved

H100 compiled-loop route probes, fp16, group=32:

| case | old route risk | new route |
|---|---:|---:|
| decode, rows 8192 | dense wins: 15.5us vs CuTe 17.3us | dense |
| decode, rows 10240 | CuTe wins: 16.9us vs dense 20.3us | CuTe |
| decode, rows 16384 | CuTe wins: 18.8us vs dense 31.4us | CuTe |
| batch 2, rows 4096 | dense wins: 11.5us vs CuTe 17.5us | dense |
| batch 2, rows 12288 | CuTe wins: 25.3us vs dense 27.5us | CuTe |
| batch 2, rows 16384 | CuTe wins: 30.0us vs dense 32.8us | CuTe |
| batch 4+ | dense wins in the tested shapes | dense |

Hybrid/RHT final-basis cache is intentionally narrow. It helps the big MLP-up style projection and loses on smaller/down projections, so the route only caches derived final-basis weights for wrapper-heavy matrices with output dim >= 10240.

## 2x Push

I tried the no-raw-FFI routes that could plausibly turn the large-decode win into 2x:

| idea | result |
|---|---|
| Shared activation tile inside the CuTe CTA | Lost. Extra `sync_threads()` cost more than the saved x reloads. |
| Rows-per-CTA sweep: 4/8/16/32 | No meaningful gain. Current 16-row CTA is already near the best point. |
| Historical CuTe variants and int4 recast | Worse than the current kernel. |
| Direct Triton prototype | Worse than current CuTe for 16384x2048 decode. |
| Micro=32 full-group CuTe variant | No win. 16384 decode was ~17.35us vs current ~17.17us; batch 2 was slower. |
| PyTorch int4pack-style 8-row cache, one warp per 8 rows | Lost to current CuTe: ~21.4us vs current ~17.2us for 16384 decode. It reduced x reloads but serialized too much K work per lane. |
| PyTorch int4pack-style 8-row cache, one warp per output row | No win: about dense-speed in compiled-loop timing and slower than current CuTe. |

The honest conclusion: 2x is possible only with a new tensor-core/MMA-style packed layout kernel, not a simple reader swap. The current simple CuTe row-major path is locally optimized enough that small tuning does not get there.

## Fronts Checked

| front | result |
|---|---|
| Projection concatenation | Mostly already present in the model: QKV, shortconv input, and MLP gate/up are already fused projections. |
| Hadamard in CuTe | Not a win. Existing Pallas/triton Hadamard is faster on H100, so this branch does not pull in the CuTe port. |
| Stock PyTorch int4pack proxy | Shows native packed kernels can beat dense through small batches, but batch 16+ still favors dense for these shapes. |
| CuTe packed-MMA prototype | Existing scratch prototype still illegal-addresses; not mergeable. Stock CUTLASS mixed-input examples are Blackwell-oriented and do not solve exact H100 MLX/AWQ group-32. |
| Model eval | Current 16k eval helper targets the older lalamo layout (`lalamo.common`) and cannot run this refactor branch without mixed imports. I did not force an invalid eval. |

## Checks

- `uv run --no-sync ruff check lalamo/compressed/hybrid.py lalamo/compressed/cute_w4a16_dot.py benchmarks/bench_w4a16_prefill.py`: passed
- `uv run --no-sync python -m py_compile lalamo/compressed/hybrid.py lalamo/compressed/cute_w4a16_dot.py benchmarks/bench_w4a16_prefill.py`: passed
- H100: `pytest tests/unit/compressed/test_hybrid.py tests/unit/compressed/test_mlx.py tests/unit/compressed/test_awq.py -q`: 72 passed
- H100 route probes over rows 4096/5120/6144/8192/10240/12288/14336/16384 and batches 1/2/4/8/16: completed
