### PR TITLE
Add unified trace export and comparison

### DIFF
--- a/lalamo/commands.py
+++ b/lalamo/commands.py
@@ -1,6 +1,6 @@
 import shutil
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -21,6 +21,17 @@ from lalamo.model_import.common import (
     import_model,
 )
 from lalamo.model_import.remote_registry import RegistryModel, RegistryModelFile
+from lalamo.models.chat_codec import Message
+from lalamo.safetensors import safe_write
+from lalamo.trace_comparator import TraceComparison, compare_trace_files
+from lalamo.tracer import (
+    export_trace_result,
+    load_traceable_model,
+    load_traceable_token_codec,
+    record_message_trace_with_tokenization,
+    record_saved_token_trace,
+    record_tokenization_trace,
+)
 from lalamo.utils.sharding import ShardingConfig
 
 
@@ -207,3 +218,47 @@ def convert(
     imported_model.model.save(output_dir)
 
     callbacks.finished_saving_model()
+
+
+def trace(
+    model_path: Path,
+    output_path: Path,
+    messages: Iterable[Message],
+    input_trace_path: Path | None = None,
+) -> None:
+    if output_path.exists():
+        raise RuntimeError(f"{output_path=} already exists, refusing to overwrite!")
+
+    messages = tuple(messages)
+    model = load_traceable_model(model_path)
+    if input_trace_path is None:
+        trace_result, tokenization_trace = record_message_trace_with_tokenization(model, messages)
+        metadata = tokenization_trace.metadata
+    else:
+        if messages:
+            raise ValueError("messages cannot be used with input_trace_path")
+        trace_result, metadata = record_saved_token_trace(model, input_trace_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as fd:
+        safe_write(fd, export_trace_result(trace_result), metadata=metadata)
+
+
+def trace_tokenization(
+    model_path: Path,
+    output_path: Path,
+    messages: Iterable[Message],
+) -> None:
+    if output_path.exists():
+        raise RuntimeError(f"{output_path=} already exists, refusing to overwrite!")
+
+    token_codec = load_traceable_token_codec(model_path)
+    tokenization_trace = record_tokenization_trace(token_codec, messages)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as fd:
+        safe_write(fd, tokenization_trace.arrays, metadata=tokenization_trace.metadata)
+
+
+def compare_traces(reference_path: Path, result_path: Path) -> TraceComparison:
+    return compare_trace_files(reference_path, result_path)

--- a/lalamo/main.py
+++ b/lalamo/main.py
@@ -35,8 +35,11 @@ from lalamo.commands import (
     PullCallbacks,
     _suggest_similar_models,
 )
+from lalamo.commands import compare_traces as _compare_traces
 from lalamo.commands import convert as _convert
 from lalamo.commands import pull as _pull
+from lalamo.commands import trace as _trace
+from lalamo.commands import trace_tokenization as _trace_tokenization
 from lalamo.model_import import ModelSpec
 from lalamo.model_import.common import FileSpec
 from lalamo.model_import.remote_registry import RegistryModel, RegistryModelFile, fetch_available_models
@@ -468,6 +471,158 @@ def pull(
         partial(CliPullCallbacks),
         overwrite=overwrite,
     )
+
+
+@app.command(help="Trace a converted model.")
+def trace(
+    model_path: Annotated[
+        Path,
+        Argument(
+            help="Path to the model directory.",
+            metavar="MODEL_PATH",
+        ),
+    ],
+    output_path: Annotated[
+        Path | None,
+        Option(
+            help="Path to save the trace to.",
+            show_default="${MODEL_PATH}/traces.safetensors",
+        ),
+    ] = None,
+    overwrite: Annotated[
+        bool,
+        Option(
+            help="Overwrite existing trace file.",
+        ),
+    ] = False,
+    message: Annotated[
+        str | None,
+        Option(
+            help="Text message to use as prompt when recording trace.",
+        ),
+    ] = None,
+    input_trace_path: Annotated[
+        Path | None,
+        Option(
+            help="Existing trace file whose token ids and positions should be replayed.",
+        ),
+    ] = None,
+) -> None:
+    if input_trace_path is None:
+        if message is None:
+            err_console.print("Pass --message when recording a new trace.")
+            raise Exit(1)
+        messages = (UserMessage(message),)
+    else:
+        if message is not None:
+            err_console.print("--message cannot be used with --input-trace-path.")
+            raise Exit(1)
+        messages = ()
+
+    if output_path is None:
+        output_path = model_path / "traces.safetensors"
+
+    if output_path.exists():
+        if not overwrite and not Confirm().ask(
+            rf"⚠️ Output [cyan]{output_path}[/cyan] already exists."
+            r" Do you want to overwrite it?",
+        ):
+            raise Exit
+        output_path.unlink()
+
+    console.print(f"🔍 Tracing [cyan]{model_path}[/cyan]")
+    _trace(model_path, output_path, messages, input_trace_path)
+    console.print(f"💾 Trace saved to [cyan]{output_path}[/cyan]")
+
+
+@app.command("trace-tokenization", help="Trace converted model tokenization.")
+def trace_tokenization(
+    model_path: Annotated[
+        Path,
+        Argument(
+            help="Path to the model directory.",
+            metavar="MODEL_PATH",
+        ),
+    ],
+    output_path: Annotated[
+        Path | None,
+        Option(
+            help="Path to save the tokenization trace to.",
+            show_default="${MODEL_PATH}/tokenization-trace.safetensors",
+        ),
+    ] = None,
+    overwrite: Annotated[
+        bool,
+        Option(
+            help="Overwrite existing trace file.",
+        ),
+    ] = False,
+    message: Annotated[
+        str | None,
+        Option(
+            help="Text message to use as prompt when recording trace.",
+        ),
+    ] = None,
+) -> None:
+    if message is None:
+        err_console.print("Pass --message when recording a tokenization trace.")
+        raise Exit(1)
+
+    if output_path is None:
+        output_path = model_path / "tokenization-trace.safetensors"
+
+    if output_path.exists():
+        if not overwrite and not Confirm().ask(
+            rf"⚠️ Output [cyan]{output_path}[/cyan] already exists."
+            r" Do you want to overwrite it?",
+        ):
+            raise Exit
+        output_path.unlink()
+
+    console.print(f"🔍 Tracing tokenization for [cyan]{model_path}[/cyan]")
+    _trace_tokenization(model_path, output_path, [UserMessage(message)])
+    console.print(f"💾 Tokenization trace saved to [cyan]{output_path}[/cyan]")
+
+
+@app.command("compare-traces", help="Compare two activation trace files.")
+def compare_traces(
+    reference_path: Annotated[
+        Path,
+        Argument(
+            help="Reference trace file.",
+            metavar="REFERENCE_TRACE",
+        ),
+    ],
+    result_path: Annotated[
+        Path,
+        Argument(
+            help="Result trace file.",
+            metavar="RESULT_TRACE",
+        ),
+    ],
+) -> None:
+    comparison = _compare_traces(reference_path, result_path)
+    failed_results = comparison.failed_results
+
+    console.print(
+        f"Compared [cyan]{len(comparison.results)}[/cyan] shared arrays; [cyan]{len(failed_results)}[/cyan] failed."
+    )
+    if comparison.reference_only_paths:
+        console.print(f"Missing result arrays: [cyan]{len(comparison.reference_only_paths)}[/cyan]")
+        for path in comparison.reference_only_paths:
+            console.print(f"  {path}")
+    if comparison.result_only_paths:
+        console.print(f"Overcaptured result arrays: [cyan]{len(comparison.result_only_paths)}[/cyan]")
+        for path in comparison.result_only_paths:
+            console.print(f"  {path}")
+
+    if not comparison.passed:
+        table = Table("Path", "Failure")
+        for result in failed_results:
+            table.add_row(result.path, result.message)
+        if failed_results:
+            console.print(table)
+        raise Exit(1)
 
 
 def _model_size_string_to_int(

--- a/lalamo/trace_comparator.py
+++ b/lalamo/trace_comparator.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from lalamo.safetensors import safe_read
+
+ATOL = 1e-2
+RTOL = 0.03
+BF16_ATOL = 0.04
+BF16_RTOL = 0.06
+
+
+@dataclass(frozen=True)
+class TraceArrayComparison:
+    path: str
+    passed: bool
+    message: str
+
+
+@dataclass(frozen=True)
+class TraceComparison:
+    results: tuple[TraceArrayComparison, ...]
+    reference_only_paths: tuple[str, ...]
+    result_only_paths: tuple[str, ...]
+
+    @property
+    def failed_results(self) -> tuple[TraceArrayComparison, ...]:
+        return tuple(result for result in self.results if not result.passed)
+
+    @property
+    def passed(self) -> bool:
+        return bool(self.results) and not self.failed_results and not self.reference_only_paths
+
+
+def compare_trace_files(reference_path: Path, result_path: Path) -> TraceComparison:
+    with jax.debug_nans(new_val=False), reference_path.open("rb") as reference_fd, result_path.open("rb") as result_fd:
+        _, reference_arrays = safe_read(reference_fd)
+        _, result_arrays = safe_read(result_fd)
+
+        reference_paths = set(reference_arrays)
+        result_paths = set(result_arrays)
+        common_paths = tuple(sorted(reference_paths & result_paths))
+        return TraceComparison(
+            results=tuple(
+                _compare_array(
+                    path,
+                    reference_arrays[path],
+                    result_arrays[path],
+                )
+                for path in common_paths
+            ),
+            reference_only_paths=tuple(sorted(reference_paths - result_paths)),
+            result_only_paths=tuple(sorted(result_paths - reference_paths)),
+        )
+
+
+def _compare_array(path: str, reference: Array, result: Array) -> TraceArrayComparison:
+    reference = jnp.asarray(jax.device_get(reference))
+    result = jnp.asarray(jax.device_get(result))
+    dtype_message = f"dtype {reference.dtype} vs {result.dtype}"
+
+    if reference.shape != result.shape:
+        return TraceArrayComparison(
+            path=path,
+            passed=False,
+            message=f"shape mismatch: {reference.shape} != {result.shape}; {dtype_message}",
+        )
+
+    if reference.dtype != result.dtype:
+        return TraceArrayComparison(
+            path=path,
+            passed=False,
+            message=f"dtype mismatch: {dtype_message}",
+        )
+
+    if jnp.issubdtype(reference.dtype, jnp.floating):
+        return _compare_floating_array(
+            path,
+            reference.astype(jnp.float32),
+            result.astype(jnp.float32),
+            dtype_message,
+            _floating_tolerance(reference.dtype, result.dtype),
+        )
+
+    violations = reference != result
+    num_violations = int(jnp.count_nonzero(violations).item())
+    return TraceArrayComparison(
+        path=path,
+        passed=num_violations == 0,
+        message=f"{num_violations} exact mismatches out of {reference.size} elements; {dtype_message}",
+    )
+
+
+def _floating_tolerance(reference_dtype: jnp.dtype, result_dtype: jnp.dtype) -> tuple[float, float]:
+    if jnp.bfloat16 in (reference_dtype, result_dtype):
+        return (BF16_ATOL, BF16_RTOL)
+    return (ATOL, RTOL)
+
+
+def _compare_floating_array(
+    path: str,
+    reference: Array,
+    result: Array,
+    dtype_message: str,
+    tolerance: tuple[float, float],
+) -> TraceArrayComparison:
+    atol, rtol = tolerance
+    if reference.size == 0:
+        return TraceArrayComparison(
+            path=path,
+            passed=True,
+            message=f"0 violations out of 0 elements; {dtype_message}",
+        )
+
+    absdiff = jnp.abs(reference - result)
+    allowed_diff = atol + rtol * jnp.abs(reference)
+    violations = absdiff > allowed_diff
+    num_violations = int(jnp.count_nonzero(violations).item())
+    max_error_index = tuple(i.item() for i in jnp.unravel_index(jnp.argmax(absdiff), absdiff.shape))
+    max_error = float(absdiff[max_error_index].item())
+    rms_error = float(jnp.sqrt(jnp.mean(jnp.square(absdiff))).item())
+    reference_nonfinite = bool(jnp.any(~jnp.isfinite(reference)).item())
+    result_nonfinite = bool(jnp.any(~jnp.isfinite(result)).item())
+
+    return TraceArrayComparison(
+        path=path,
+        passed=num_violations == 0 and not reference_nonfinite and not result_nonfinite,
+        message=(
+            f"{num_violations} violations out of {reference.size} elements; "
+            f"atol={atol:.3g}; rtol={rtol:.3g}; "
+            f"worst {max_error:.3g} at {max_error_index}; "
+            f"rms {rms_error:.3g}; reference_nonfinite={reference_nonfinite}; "
+            f"result_nonfinite={result_nonfinite}; {dtype_message}"
+        ),
+    )

--- a/lalamo/tracer.py
+++ b/lalamo/tracer.py
@@ -1,0 +1,380 @@
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import NamedTuple, NotRequired, TypedDict, cast
+
+import jax
+import jax.numpy as jnp
+from jax.experimental.checkify import checkify, div_checks, nan_checks, user_checks
+from jax.sharding import AxisType
+from jaxtyping import Array, Int
+from tokenizers import Tokenizer
+
+from lalamo.exportable import ExportResults
+from lalamo.initializer import EmptyInitializer
+from lalamo.model import Model, ModelConfig
+from lalamo.models import ClassifierModel, LanguageModel
+from lalamo.models.chat_codec import ChatCodec, ChatCodecConfig, Message
+from lalamo.models.language_model import GenerationConfig, LanguageModelConfig
+from lalamo.modules import (
+    ClassifierForwardPassConfig,
+    ClassifierResult,
+    DecoderConfig,
+    DecoderForwardPassConfig,
+    DecoderResult,
+    Keychain,
+)
+from lalamo.safetensors import safe_read
+from lalamo.utils.json import JSON
+from lalamo.utils.sharding import ShardingConfig
+from lalamo.weight_matrix import FullPrecisionSpec, Layout
+
+type TraceableModel = LanguageModel | ClassifierModel
+type TraceResult = DecoderResult | ClassifierResult
+TRACE_TOKEN_IDS_PATH = "activation_trace.token_ids"
+TRACE_TOKEN_POSITIONS_PATH = "activation_trace.token_positions"
+
+
+class TokenizationTrace(NamedTuple):
+    arrays: Mapping[str, Array]
+    metadata: dict[str, str]
+
+
+class UzuGenerationConfig(TypedDict):
+    stop_token_ids: list[int]
+    temperature: float | None
+    top_k: int | None
+    top_p: float | None
+    min_p: float | None
+    banned_tokens: list[int] | None
+
+
+class UzuMessageProcessorConfig(TypedDict):
+    prompt_template: str
+    output_parser_regex: str | None
+    system_role_name: str
+    user_role_name: str
+    assistant_role_name: str
+    eos_token: str | None
+    bos_token: str | None
+    default_system_prompt: str | None
+
+
+class UzuLanguageModelConfig(TypedDict):
+    model_config: JSON
+    message_processor_config: UzuMessageProcessorConfig
+    generation_config: UzuGenerationConfig
+
+
+class UzuModelMetadata(TypedDict):
+    model_type: NotRequired[str]
+    model_config: UzuLanguageModelConfig
+
+
+def trace_sharding_config() -> ShardingConfig:
+    devices = jax.devices()
+    first_device, *_ = devices
+    if first_device.platform == "cpu":
+        devices = devices[:1]
+    mesh = jax.make_mesh(
+        (len(devices),),
+        ("replica",),
+        axis_types=(AxisType.Auto,),
+        devices=devices,
+    )
+    return ShardingConfig(mesh=mesh)
+
+
+def load_traceable_model(model_path: Path) -> TraceableModel:
+    with (model_path / "config.json").open() as fd:
+        config = json.load(fd)
+
+    if "type" in config:
+        model = Model.load(model_path, ShardingConfig.replicated())
+        if isinstance(model, (LanguageModel, ClassifierModel)):
+            return model
+        raise TypeError(f"Unsupported model type for tracing: {type(model).__name__}")
+
+    if config["model_type"] == "language_model":
+        return _load_uzu_language_model(model_path, cast("UzuModelMetadata", config))
+
+    raise TypeError(f"Unsupported model type for tracing: {config['model_type']}")
+
+
+def load_traceable_token_codec(model_path: Path) -> ChatCodec:
+    with (model_path / "config.json").open() as fd:
+        config = json.load(fd)
+    tokenizer = Tokenizer.from_file(str(model_path / "tokenizer.json"))
+
+    if "type" in config:
+        model_config = ModelConfig.from_json(config)
+        token_codec_config = model_config.token_codec_config
+        if isinstance(token_codec_config, ChatCodecConfig):
+            return token_codec_config.init(tokenizer)
+        raise TypeError(f"Unsupported token codec for tracing: {type(token_codec_config).__name__}")
+
+    if config["model_type"] == "language_model":
+        return _uzu_language_model_config(cast("UzuModelMetadata", config)).token_codec_config.init(tokenizer)
+
+    raise TypeError(f"Unsupported model type for tracing: {config['model_type']}")
+
+
+def _load_uzu_language_model(model_path: Path, metadata: UzuModelMetadata) -> LanguageModel:
+    config = _uzu_language_model_config(metadata)
+    with (model_path / "model.safetensors").open("rb") as fd:
+        _, uzu_arrays = safe_read(fd)
+        arrays: dict[str, Array] = {}
+        export_metadata = {}
+        for path in uzu_arrays:
+            mapped_path, spec_path, spec = _map_uzu_export_path(path, uzu_arrays[path])
+            arrays[mapped_path] = uzu_arrays[path]
+            if spec_path is not None:
+                export_metadata[spec_path] = spec
+
+        weight_dtype = arrays["decoder.embedding.embedding.weights"].dtype
+        template = config.init(
+            Tokenizer.from_file(str(model_path / "tokenizer.json")),
+            EmptyInitializer(weight_dtype, ShardingConfig.replicated()),
+        )
+        result = template.load_exported(
+            ExportResults(arrays=arrays, metadata=export_metadata),
+        )
+
+    assert isinstance(result, LanguageModel)
+    return result
+
+
+def _uzu_language_model_config(metadata: UzuModelMetadata) -> LanguageModelConfig:
+    model_config = metadata["model_config"]
+    message_config = model_config["message_processor_config"]
+    generation_config = model_config["generation_config"]
+    banned_tokens = generation_config["banned_tokens"]
+    return LanguageModelConfig(
+        token_codec_config=ChatCodecConfig(
+            prompt_template=message_config["prompt_template"],
+            output_parser_regex=message_config["output_parser_regex"],
+            system_role_name=message_config["system_role_name"],
+            user_role_name=message_config["user_role_name"],
+            assistant_role_name=message_config["assistant_role_name"],
+            eos_token=message_config["eos_token"],
+            bos_token=message_config["bos_token"],
+            default_system_prompt=message_config["default_system_prompt"],
+        ),
+        decoder_config=DecoderConfig.from_json(model_config["model_config"]),
+        generation_config=GenerationConfig(
+            stop_token_ids=tuple(generation_config["stop_token_ids"]),
+            temperature=generation_config["temperature"],
+            top_k=generation_config["top_k"],
+            top_p=generation_config["top_p"],
+            min_p=generation_config["min_p"],
+            banned_tokens=None if banned_tokens is None else tuple(banned_tokens),
+        ),
+    )
+
+
+def _map_uzu_export_path(path: str, array: Array) -> tuple[str, str | None, JSON | None]:
+    if path == "embedding.weights":
+        if not jnp.issubdtype(array.dtype, jnp.floating):
+            raise TypeError("Only full-precision uzu exports can be traced.")
+        return (
+            "decoder.embedding.embedding.weights",
+            "decoder.embedding.embedding.spec",
+            FullPrecisionSpec(layout=Layout.INPUT_OUTPUT).to_json(),
+        )
+    if path.startswith("transformer.global_rope."):
+        return ("decoder.transformer.ropes.0." + path.removeprefix("transformer.global_rope."), None, None)
+    if path.endswith(".weights"):
+        if not jnp.issubdtype(array.dtype, jnp.floating):
+            raise TypeError("Only full-precision uzu exports can be traced.")
+        mapped_path = f"decoder.{path}.weights"
+        return (
+            mapped_path,
+            mapped_path.removesuffix(".weights") + ".spec",
+            FullPrecisionSpec().to_json(),
+        )
+    return (f"decoder.{path}", None, None)
+
+
+def record_message_trace(model: TraceableModel, messages: Iterable[Message]) -> TraceResult:
+    result, _ = record_message_trace_with_tokenization(model, messages)
+    return result
+
+
+def record_message_trace_with_tokenization(
+    model: TraceableModel,
+    messages: Iterable[Message],
+) -> tuple[TraceResult, TokenizationTrace]:
+    tokenization_trace = record_tokenization_trace(model.token_codec, messages)
+    token_ids = tokenization_trace.arrays[TRACE_TOKEN_IDS_PATH]
+    token_positions = tokenization_trace.arrays[TRACE_TOKEN_POSITIONS_PATH]
+    _check_token_trace_inputs(model, token_ids, token_positions)
+    token_sharding = model.sharding_config.make_sharding((None, None))
+    result = record_token_trace(
+        model=model,
+        token_ids=jax.device_put(token_ids, token_sharding),
+        token_positions=jax.device_put(token_positions, token_sharding),
+    )
+    return result, tokenization_trace
+
+
+def record_saved_token_trace(model: TraceableModel, trace_path: Path) -> tuple[TraceResult, dict[str, str] | None]:
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        token_ids = arrays[TRACE_TOKEN_IDS_PATH]
+        token_positions = arrays[TRACE_TOKEN_POSITIONS_PATH]
+        _check_token_trace_inputs(model, token_ids, token_positions)
+
+    token_sharding = model.sharding_config.make_sharding((None, None))
+    return (
+        record_token_trace(
+            model=model,
+            token_ids=jax.device_put(token_ids, token_sharding),
+            token_positions=jax.device_put(token_positions, token_sharding),
+        ),
+        metadata,
+    )
+
+
+def _check_token_trace_inputs(model: TraceableModel, token_ids: Array, token_positions: Array) -> None:
+    if token_ids.dtype != jnp.int32:
+        raise TypeError(f"{TRACE_TOKEN_IDS_PATH} must be int32, got {token_ids.dtype}")
+    if token_positions.dtype != jnp.int32:
+        raise TypeError(f"{TRACE_TOKEN_POSITIONS_PATH} must be int32, got {token_positions.dtype}")
+    if token_ids.ndim != 2:
+        raise ValueError(f"{TRACE_TOKEN_IDS_PATH} must have shape [1, suffix_tokens], got {token_ids.shape}")
+    batch_size, suffix_tokens = token_ids.shape
+    if batch_size != 1 or suffix_tokens == 0:
+        raise ValueError(f"{TRACE_TOKEN_IDS_PATH} must have shape [1, suffix_tokens], got {token_ids.shape}")
+    if token_positions.shape != token_ids.shape:
+        raise ValueError(
+            f"{TRACE_TOKEN_POSITIONS_PATH} shape {token_positions.shape} must match"
+            f" {TRACE_TOKEN_IDS_PATH} {token_ids.shape}"
+        )
+
+    token_ids = jnp.asarray(jax.device_get(token_ids))
+    token_positions = jnp.asarray(jax.device_get(token_positions))
+    if isinstance(model, LanguageModel):
+        vocab_size = model.decoder.vocab_size
+        if model.decoder.per_layer_embedding is not None:
+            vocab_size = min(vocab_size, model.decoder.per_layer_embedding.token_embedding.shape[0])
+        ropes = model.decoder.transformer.ropes
+    elif isinstance(model, ClassifierModel):
+        vocab_size = model.classifier.embedding.vocab_size
+        ropes = model.classifier.transformer.ropes
+    else:
+        raise TypeError(f"Unsupported model type for tracing: {type(model).__name__}")
+
+    if bool(jnp.any(token_ids < 0).item()) or bool(jnp.any(token_ids >= vocab_size).item()):
+        raise ValueError(f"{TRACE_TOKEN_IDS_PATH} must contain token ids in [0, {vocab_size})")
+    if bool(jnp.any(token_positions < 0).item()):
+        raise ValueError(f"{TRACE_TOKEN_POSITIONS_PATH} must contain nonnegative positions")
+
+    if ropes:
+        position_capacity = min(rope.config.max_sequence_length for rope in ropes)
+        if bool(jnp.any(token_positions >= position_capacity).item()):
+            raise ValueError(f"{TRACE_TOKEN_POSITIONS_PATH} must contain positions in [0, {position_capacity})")
+
+
+def record_tokenization_trace(token_codec: ChatCodec, messages: Iterable[Message]) -> TokenizationTrace:
+    messages = tuple(messages)
+    request = token_codec.request_to_dict(messages, enable_thinking=True)
+    rendered_request = token_codec.render_request(messages)
+    encoding = token_codec.tokenizer.encode(rendered_request, add_special_tokens=False)
+    token_ids = jnp.asarray(encoding.ids, dtype=jnp.int32)[None, :]
+    batch, tokens = token_ids.shape
+    assert batch == 1
+    if tokens == 0:
+        raise ValueError("Tokenization trace must contain at least one token.")
+    return TokenizationTrace(
+        arrays={
+            TRACE_TOKEN_IDS_PATH: token_ids,
+            TRACE_TOKEN_POSITIONS_PATH: jnp.arange(tokens, dtype=jnp.int32)[None, :],
+        },
+        metadata={
+            "add_special_tokens": "false",
+            "prompt_template": token_codec.config.prompt_template,
+            "rendered_request": rendered_request,
+            "request": json.dumps(request, ensure_ascii=False, separators=(",", ":")),
+            "tokens": json.dumps(encoding.tokens, ensure_ascii=False, separators=(",", ":")),
+        },
+    )
+
+
+def export_trace_result(result: TraceResult) -> Mapping[str, Array]:
+    arrays = dict(result.export().arrays)
+    if result.activation_trace is not None:
+        trace_dtype = result.activation_trace.output_norm.dtype
+        arrays = {
+            path: array.astype(trace_dtype)
+            if path.endswith("logits") and jnp.issubdtype(array.dtype, jnp.floating)
+            else array
+            for path, array in arrays.items()
+        }
+    return arrays
+
+
+def record_token_trace(
+    model: TraceableModel,
+    token_ids: Int[Array, "batch suffix_tokens"],
+    token_positions: Int[Array, "batch suffix_tokens"],
+) -> TraceResult:
+    keychain = Keychain.init(0, sharding_config=model.sharding_config)
+
+    with jax.set_mesh(model.sharding_config.mesh), jax.disable_jit():
+        if isinstance(model, LanguageModel):
+            return model.decoder(
+                token_ids=token_ids,
+                token_positions=token_positions,
+                return_updated_state=True,
+                return_activation_trace=True,
+                forward_pass_config=DecoderForwardPassConfig.for_inference(),
+                keychain=keychain,
+            )
+
+        if isinstance(model, ClassifierModel):
+            return model.classifier(
+                token_ids=token_ids,
+                token_positions=token_positions,
+                return_activation_trace=True,
+                forward_pass_config=ClassifierForwardPassConfig.for_inference(),
+                keychain=keychain,
+            )
+
+    raise TypeError(f"Unsupported model type for tracing: {type(model).__name__}")
+
+
+def record_checked_token_trace(
+    model: TraceableModel,
+    token_ids: Int[Array, "batch suffix_tokens"],
+    token_positions: Int[Array, "batch suffix_tokens"],
+) -> TraceResult:
+    keychain = Keychain.init(0, sharding_config=model.sharding_config)
+    errors = nan_checks | div_checks | user_checks
+
+    with jax.set_mesh(model.sharding_config.mesh), jax.disable_jit():
+        if isinstance(model, LanguageModel):
+            err, result = checkify(model.decoder.__call__, errors=errors)(
+                token_ids=token_ids,
+                token_positions=token_positions,
+                return_updated_state=True,
+                return_activation_trace=True,
+                forward_pass_config=DecoderForwardPassConfig.for_tracer_tests(),
+                keychain=keychain,
+            )
+            err.throw()
+            assert isinstance(result, DecoderResult)
+            return result
+
+        if isinstance(model, ClassifierModel):
+            err, result = checkify(model.classifier.__call__, errors=errors)(
+                token_ids=token_ids,
+                token_positions=token_positions,
+                return_activation_trace=True,
+                forward_pass_config=ClassifierForwardPassConfig.for_tracer_tests(),
+                keychain=keychain,
+            )
+            err.throw()
+            assert isinstance(result, ClassifierResult)
+            return result
+
+    raise TypeError(f"Unsupported model type for tracing: {type(model).__name__}")

--- a/tests/tracer/test_huggingface_models.py
+++ b/tests/tracer/test_huggingface_models.py
@@ -1,8 +1,29 @@
+import gc
+import json
+from pathlib import Path
+from typing import cast
+
+import jax
+import jax.numpy as jnp
 import pytest
 import torch
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
+from lalamo.model_import.common import _import_chat_codec, import_model
+from lalamo.model_import.model_spec import LanguageModelSpec
+from lalamo.model_registry import ModelRegistry
+from lalamo.models import LanguageModel
+from lalamo.models.chat_codec import UserMessage
+from lalamo.safetensors import safe_write
+from lalamo.trace_comparator import compare_trace_files
+from lalamo.tracer import (
+    export_trace_result,
+    record_checked_token_trace,
+    record_tokenization_trace,
+    trace_sharding_config,
+)
 from tests.helpers import unsi
-from tests.tracer.tracer import DType, ModelTestSpec, _test_model
+from tests.tracer.tracer import DType, ModelTestSpec, _test_model, configure_precision_for_tests
 from tests.tracer.tracer_huggingface import HFDecoderTracer, ModernBertTracer
 
 MODEL_LIST = [
@@ -27,6 +48,82 @@ MODEL_LIST += (
 CLASSIFIER_MODEL_LIST = [
     ModelTestSpec("trymirai/chat-moderation-router", DType.FLOAT32),
 ]
+
+
+def test_hf_chat_tokenization_matches_lalamo() -> None:
+    model_repo = "Qwen/Qwen3.5-0.8B"
+    model_spec = cast(
+        "LanguageModelSpec",
+        ModelRegistry.build(allow_third_party_plugins=False).repo_to_model[model_repo],
+    )
+    tokenizer, token_codec_config = _import_chat_codec(model_spec)
+    trace_result = record_tokenization_trace(token_codec_config.init(tokenizer), [UserMessage("Tell me about London")])
+    request = json.loads(trace_result.metadata["request"])
+    hf_tokenizer = cast("PreTrainedTokenizerBase", AutoTokenizer.from_pretrained(model_repo))
+
+    hf_rendered = hf_tokenizer.apply_chat_template(
+        request["messages"],
+        add_generation_prompt=request["add_generation_prompt"],
+        tokenize=False,
+        enable_thinking=request["enable_thinking"],
+    )
+    hf_token_ids = hf_tokenizer.apply_chat_template(
+        request["messages"],
+        add_generation_prompt=request["add_generation_prompt"],
+        tokenize=True,
+        return_dict=False,
+        enable_thinking=request["enable_thinking"],
+    )
+
+    assert trace_result.metadata["rendered_request"] == hf_rendered
+    assert trace_result.arrays["activation_trace.token_ids"].tolist()[0] == hf_token_ids
+
+
+def test_hf_lm_trace_files_compare(tmp_path: Path) -> None:
+    test_spec = ModelTestSpec("Qwen/Qwen3-0.6B", DType.FLOAT32, num_tokens=32, token_stride=1)
+    assert test_spec.dtype is not None
+    configure_precision_for_tests()
+    sharding_config = trace_sharding_config()
+    token_sharding = sharding_config.make_sharding((None, None))
+    token_ids = jax.device_put(jnp.arange(test_spec.num_tokens, dtype=jnp.int32)[None, :], token_sharding)
+    token_positions = jax.device_put(
+        jnp.arange(test_spec.num_tokens, dtype=jnp.int32)[None, :],
+        token_sharding,
+    )
+
+    hf_tracer = HFDecoderTracer.load(test_spec.model_repo, test_spec.dtype)
+    imported_model = import_model(
+        test_spec.model_repo,
+        sharding_config=sharding_config,
+        context_length=test_spec.num_tokens,
+        dtype=test_spec.dtype.jax_dtype,
+    )
+    model = imported_model.model
+    assert isinstance(model, LanguageModel)
+    lalamo_result = record_checked_token_trace(model, token_ids, token_positions)
+
+    reference_path = tmp_path / "hf.safetensors"
+    result_path = tmp_path / "lalamo.safetensors"
+    with reference_path.open("wb") as fd:
+        safe_write(fd, hf_tracer.export_trace(token_ids, token_positions))
+    with result_path.open("wb") as fd:
+        safe_write(fd, export_trace_result(lalamo_result))
+
+    del model
+    del imported_model
+    del lalamo_result
+    del hf_tracer
+    gc.collect()
+    jax.clear_caches()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert comparison.passed, "\n".join(
+        [f"{result.path}: {result.message}" for result in comparison.failed_results]
+        + [f"missing result array: {path}" for path in comparison.reference_only_paths]
+    )
 
 
 @pytest.mark.parametrize("test_spec", MODEL_LIST, ids=[m.model_repo for m in MODEL_LIST])

--- a/tests/tracer/tracer.py
+++ b/tests/tracer/tracer.py
@@ -12,26 +12,22 @@ import jax
 import jax.numpy as jnp
 import pytest
 import torch
-from jax.sharding import AxisType
 from jaxtyping import Array
 from transformers.models.gpt_oss.modeling_gpt_oss import GptOssAttention
 
 from lalamo import ClassifierModel, LanguageModel
 from lalamo.model_import.common import import_model
-from lalamo.module import Keychain
 from lalamo.modules.classifier import (
     ClassifierActivationTrace,
-    ClassifierForwardPassConfig,
     ClassifierResult,
 )
 from lalamo.modules.decoder import (
     DecoderActivationTrace,
-    DecoderForwardPassConfig,
     DecoderResult,
 )
+from lalamo.tracer import record_checked_token_trace, trace_sharding_config
 from lalamo.utils.memory import get_available_bytes_on_default_device
-from lalamo.utils.sharding import ShardingConfig
-from tests.common import assert_close, checkify_forward
+from tests.common import assert_close
 from tests.helpers import si, unsi
 
 MLX_AVAILABLE = importlib.util.find_spec("mlx")
@@ -39,20 +35,6 @@ if MLX_AVAILABLE:
     import mlx.core as mx
 
 FRACTION_OF_ALLOWED_VIOLATIONS = 0.03
-
-
-def _tracer_sharding_config() -> ShardingConfig:
-    devices = jax.devices()
-    first_device, *_ = devices
-    if first_device.platform == "cpu":
-        devices = devices[:1]
-    mesh = jax.make_mesh(
-        (len(devices),),
-        ("replica",),
-        axis_types=(AxisType.Auto,),
-        devices=devices,
-    )
-    return ShardingConfig(mesh=mesh)
 
 
 class DType(Enum):
@@ -397,8 +379,14 @@ class ModelTracer[ArrayT, LayerT, RMSNormT, AttentionT, MlpT]:
         hf_token_positions = self.from_jax(result.activation_trace.token_positions)
         hf_hidden_states, hf_last_norm_output, hf_output_logits = self.forward(hf_input_ids, hf_token_positions)
 
+        if len(hf_hidden_states) == len(result.activation_trace.layer_results) + 1:
+            hf_layer_inputs_by_layer = hf_hidden_states[:-1]
+        else:
+            assert len(hf_hidden_states) == len(result.activation_trace.layer_results)
+            hf_layer_inputs_by_layer = hf_hidden_states
+
         for i, (hf_layer_inputs, layer_result) in enumerate(
-            zip(hf_hidden_states, result.activation_trace.layer_results, strict=False),
+            zip(hf_layer_inputs_by_layer, result.activation_trace.layer_results, strict=True),
         ):
             layer_activation_trace = layer_result.activation_trace
             assert layer_activation_trace is not None
@@ -456,7 +444,7 @@ def _test_model(test_spec: ModelTestSpec, model_tracer: type[ModelTracer]) -> No
 
     configure_precision_for_tests()
 
-    sharding_config = _tracer_sharding_config()
+    sharding_config = trace_sharding_config()
     batch_sequence_sharding = sharding_config.make_sharding((None, None))
     token_ids = jax.device_put(
         jnp.arange(0, test_spec.num_tokens, dtype=jnp.int32)[None, :],
@@ -490,31 +478,9 @@ def _test_model(test_spec: ModelTestSpec, model_tracer: type[ModelTracer]) -> No
             dtype=import_dtype,
         )
         model = imported_model.model
-        keychain = Keychain.init(0, sharding_config=sharding_config)
-        with jax.disable_jit():
-            if isinstance(model, LanguageModel):
-                forward_pass_config = DecoderForwardPassConfig.for_tracer_tests()
-                err, inference_results = checkify_forward(model.decoder)(
-                    token_ids=token_ids,
-                    token_positions=token_positions,
-                    return_updated_state=True,
-                    return_activation_trace=True,
-                    forward_pass_config=forward_pass_config,
-                    keychain=keychain,
-                )
-                err.throw()
-            elif isinstance(model, ClassifierModel):
-                forward_pass_config = ClassifierForwardPassConfig.for_tracer_tests()
-                err, inference_results = checkify_forward(model.classifier)(
-                    token_ids=token_ids,
-                    token_positions=token_positions,
-                    return_activation_trace=True,
-                    forward_pass_config=forward_pass_config,
-                    keychain=keychain,
-                )
-                err.throw()
-            else:
-                raise TypeError(f"Unsupported model type for tracing: {type(model).__name__}")
+        if not isinstance(model, (LanguageModel, ClassifierModel)):
+            raise TypeError(f"Unsupported model type for tracing: {type(model).__name__}")
+        inference_results = record_checked_token_trace(model, token_ids, token_positions)
 
         tracer.match_activations(inference_results)
     finally:

--- a/tests/tracer/tracer_huggingface.py
+++ b/tests/tracer/tracer_huggingface.py
@@ -485,6 +485,72 @@ class HFDecoderTracer(
         assert isinstance(result, DecoderResult)
         return self.from_jax(result.activation_trace.output_norm[None, ...])
 
+    def _position_embeddings(
+        self,
+        attention: HFAttention | Gemma3Attention | HFDeltaNetAttention,
+        position_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if Qwen3NextGatedDeltaNet is not None and isinstance(
+            attention,
+            (Qwen3NextGatedDeltaNet, Qwen3_5GatedDeltaNet),
+        ):
+            return None
+        layer_type = "sliding_attention" if getattr(attention, "is_sliding", False) else "full_attention"
+        return _rope_forward(
+            self.text_model.rotary_emb, torch.empty((), dtype=torch.float32), position_ids, layer_type, self.device
+        )
+
+    @torch.no_grad()
+    def export_trace(self, token_ids: Array, token_positions: Array) -> dict[str, Array]:
+        torch_token_ids = self.from_jax(token_ids)
+        torch_token_positions = self.from_jax(token_positions)
+        hidden_states = self.embedding(torch_token_ids)
+        arrays = {
+            "activation_trace.token_ids": token_ids,
+            "activation_trace.token_positions": token_positions,
+        }
+
+        for layer_index, layer in enumerate(self.iterate_layers()):
+            path = f"activation_trace.layer_results.{layer_index}"
+            activation_path = f"{path}.activation_trace"
+            arrays[f"{activation_path}.inputs"] = self.to_jax(hidden_states)
+
+            pre_mixer_norm = self.rmsnorm(self.layer_pre_attention_norm(layer), hidden_states)
+            attention = self.layer_attention(layer)
+            mixer = self.attention(
+                attention, pre_mixer_norm, self._position_embeddings(attention, torch_token_positions)
+            )
+            arrays[f"{activation_path}.pre_mixer_norm"] = self.to_jax(pre_mixer_norm)
+            arrays[f"{activation_path}.mixer"] = self.to_jax(mixer)
+
+            post_mixer_norm = self.layer_post_attention_norm(layer)
+            if post_mixer_norm is None:
+                mlp_inputs = hidden_states + mixer
+            else:
+                normalized_mixer = self.rmsnorm(post_mixer_norm, mixer)
+                arrays[f"{activation_path}.post_mixer_norm"] = self.to_jax(normalized_mixer)
+                mlp_inputs = hidden_states + normalized_mixer
+
+            pre_mlp_norm = self.rmsnorm(self.layer_pre_mlp_norm(layer), mlp_inputs)
+            mlp = self.mlp(self.layer_mlp(layer), pre_mlp_norm)
+            arrays[f"{activation_path}.mlp_inputs"] = self.to_jax(mlp_inputs)
+            arrays[f"{activation_path}.pre_mlp_norm"] = self.to_jax(pre_mlp_norm)
+            arrays[f"{activation_path}.mlp"] = self.to_jax(mlp)
+
+            post_mlp_norm = self.layer_post_mlp_norm(layer)
+            if post_mlp_norm is None:
+                hidden_states = mlp_inputs + mlp
+            else:
+                normalized_mlp = self.rmsnorm(post_mlp_norm, mlp)
+                arrays[f"{activation_path}.post_mlp_norm"] = self.to_jax(normalized_mlp)
+                hidden_states = mlp_inputs + normalized_mlp
+            arrays[f"{path}.outputs"] = self.to_jax(hidden_states)
+
+        output_norm = self.rmsnorm(self.output_norm(), hidden_states)
+        arrays["activation_trace.output_norm"] = self.to_jax(output_norm)
+        arrays["logits"] = self.to_jax(self.readout(output_norm))
+        return arrays
+
     @classmethod
     def load(cls, model_repo: str, dtype: DType | None) -> Self:
         hf_model, device = _load_hf_model(AutoModelForCausalLM, model_repo, dtype)

--- a/tests/unit/test_trace_comparator.py
+++ b/tests/unit/test_trace_comparator.py
@@ -1,0 +1,250 @@
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+from typer.testing import CliRunner
+
+from lalamo.commands import compare_traces
+from lalamo.main import app
+from lalamo.safetensors import safe_write
+from lalamo.trace_comparator import compare_trace_files
+from tests.conftest import RunLalamo
+
+
+def _write_trace(path: Path, arrays: dict[str, jnp.ndarray]) -> None:
+    with path.open("wb") as fd:
+        safe_write(fd, arrays)
+
+
+def test_compare_trace_files_compares_shared_arrays(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(
+        reference_path,
+        {
+            "activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32),
+            "activation_trace.output_norm": jnp.asarray([[1.0, 2.0]], dtype=jnp.float32),
+        },
+    )
+    _write_trace(
+        result_path,
+        {
+            "activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32),
+            "activation_trace.output_norm": jnp.asarray([[1.0, 2.001]], dtype=jnp.float32),
+            "result_only": jnp.asarray([1], dtype=jnp.int32),
+        },
+    )
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert comparison.passed
+    assert comparison.reference_only_paths == ()
+    assert comparison.result_only_paths == ("result_only",)
+
+
+def test_compare_trace_files_fails_missing_result_arrays(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(
+        reference_path,
+        {
+            "activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32),
+            "activation_trace.output_norm": jnp.asarray([[1.0, 2.0]], dtype=jnp.float32),
+        },
+    )
+    _write_trace(result_path, {"activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert comparison.reference_only_paths == ("activation_trace.output_norm",)
+
+
+def test_compare_trace_files_reports_failures(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32)})
+    _write_trace(result_path, {"activation_trace.token_ids": jnp.asarray([[1, 3]], dtype=jnp.int32)})
+
+    comparison = compare_traces(reference_path, result_path)
+
+    (failed_result,) = comparison.failed_results
+    assert failed_result.path == "activation_trace.token_ids"
+    assert not comparison.passed
+
+
+def test_compare_trace_files_uses_bfloat16_tolerance(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    reference = jnp.zeros((100,), dtype=jnp.bfloat16)
+    result = reference.at[:2].set(jnp.asarray(0.03, dtype=jnp.bfloat16))
+    _write_trace(reference_path, {"activation_trace.output_norm": reference})
+    _write_trace(result_path, {"activation_trace.output_norm": result})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert comparison.passed
+    assert "atol=0.04" in comparison.results[0].message
+
+
+def test_compare_trace_files_reports_float_dtype_mismatches(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"activation_trace.output_norm": jnp.asarray([1.0], dtype=jnp.float32)})
+    _write_trace(result_path, {"activation_trace.output_norm": jnp.asarray([1.0], dtype=jnp.bfloat16)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert "dtype mismatch" in comparison.failed_results[0].message
+
+
+def test_compare_trace_files_rejects_single_bfloat16_outlier(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    reference = jnp.zeros((34,), dtype=jnp.bfloat16)
+    result = reference.at[0].set(jnp.asarray(0.5, dtype=jnp.bfloat16))
+    _write_trace(reference_path, {"activation_trace.output_norm": reference})
+    _write_trace(result_path, {"activation_trace.output_norm": result})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert "1 violations" in comparison.failed_results[0].message
+
+
+def test_compare_trace_files_keeps_float32_tolerance_strict(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    reference = jnp.zeros((100,), dtype=jnp.float32)
+    result = reference.at[:2].set(0.03)
+    _write_trace(reference_path, {"activation_trace.output_norm": reference})
+    _write_trace(result_path, {"activation_trace.output_norm": result})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert "atol=0.01" in comparison.failed_results[0].message
+
+
+def test_compare_trace_files_rejects_tiny_float_mismatches(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"activation_trace.output_norm": jnp.asarray([0.0], dtype=jnp.float32)})
+    _write_trace(result_path, {"activation_trace.output_norm": jnp.asarray([0.03], dtype=jnp.float32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert "1 violations" in comparison.failed_results[0].message
+
+
+def test_compare_trace_files_handles_empty_float_arrays(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"activation_trace.output_norm": jnp.asarray([], dtype=jnp.float32)})
+    _write_trace(result_path, {"activation_trace.output_norm": jnp.asarray([], dtype=jnp.float32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert comparison.passed
+    assert "0 elements" in comparison.results[0].message
+
+
+def test_compare_trace_files_rejects_nonfinite_values(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    with jax.debug_nans(new_val=False):
+        _write_trace(reference_path, {"activation_trace.output_norm": jnp.asarray([jnp.nan], dtype=jnp.float32)})
+    _write_trace(result_path, {"activation_trace.output_norm": jnp.asarray([0.0], dtype=jnp.float32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert "reference_nonfinite=True" in comparison.failed_results[0].message
+
+
+def test_compare_trace_files_reports_dtype_mismatches(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32)})
+    _write_trace(result_path, {"activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.uint32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    (failed_result,) = comparison.failed_results
+    assert "dtype mismatch" in failed_result.message
+
+
+def test_compare_trace_files_reports_shape_mismatches(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"activation_trace.output_norm": jnp.zeros((1, 2), dtype=jnp.float32)})
+    _write_trace(result_path, {"activation_trace.output_norm": jnp.zeros((2, 1), dtype=jnp.float32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    (failed_result,) = comparison.failed_results
+    assert "shape mismatch" in failed_result.message
+
+
+def test_compare_trace_files_requires_shared_arrays(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"reference": jnp.asarray([1], dtype=jnp.int32)})
+    _write_trace(result_path, {"result": jnp.asarray([1], dtype=jnp.int32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert comparison.reference_only_paths == ("reference",)
+
+
+def test_compare_trace_files_rejects_empty_reference(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {})
+    _write_trace(result_path, {"result": jnp.asarray([1], dtype=jnp.int32)})
+
+    comparison = compare_trace_files(reference_path, result_path)
+
+    assert not comparison.passed
+    assert comparison.results == ()
+    assert comparison.result_only_paths == ("result",)
+
+
+def test_compare_traces_cli(tmp_path: Path, run_lalamo: RunLalamo) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(
+        reference_path,
+        {
+            "activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32),
+        },
+    )
+    _write_trace(
+        result_path,
+        {
+            "activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32),
+            "result_only": jnp.asarray([1], dtype=jnp.int32),
+        },
+    )
+
+    output = run_lalamo("compare-traces", str(reference_path), str(result_path))
+
+    assert "1 shared arrays" in output
+    assert "Overcaptured result arrays" in output
+    assert "result_only" in output
+
+
+def test_compare_traces_cli_fails_on_mismatched_arrays(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.safetensors"
+    result_path = tmp_path / "result.safetensors"
+    _write_trace(reference_path, {"activation_trace.token_ids": jnp.asarray([[1, 2]], dtype=jnp.int32)})
+    _write_trace(result_path, {"activation_trace.token_ids": jnp.asarray([[1, 3]], dtype=jnp.int32)})
+
+    result = CliRunner().invoke(app, ["compare-traces", str(reference_path), str(result_path)], terminal_width=240)
+
+    assert result.exit_code == 1
+    assert "1 failed" in result.output
+    assert "activation_trace.token_ids" in result.output

--- a/tests/unit/test_tracer.py
+++ b/tests/unit/test_tracer.py
@@ -1,0 +1,474 @@
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import jax
+import jax.numpy as jnp
+import pytest
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+
+from lalamo.commands import trace, trace_tokenization
+from lalamo.initializer import RandomInitializer
+from lalamo.models import GenerationConfig, LanguageModel, LanguageModelConfig
+from lalamo.models.chat_codec import ChatCodecConfig, UserMessage
+from lalamo.modules import (
+    DecoderConfig,
+    DenseMLPConfig,
+    Identity,
+    LinearConfig,
+    NormalizationConfig,
+    TiedEmbeddingConfig,
+    TransformerConfig,
+    TransformerLayerConfig,
+    UnscaledRoPEConfig,
+    UpcastMode,
+)
+from lalamo.modules.token_mixers.attention import AttentionConfig
+from lalamo.safetensors import safe_read, safe_write
+from lalamo.tracer import (
+    export_trace_result,
+    load_traceable_model,
+    load_traceable_token_codec,
+    record_message_trace,
+    record_tokenization_trace,
+    trace_sharding_config,
+)
+from lalamo.utils.json import JSON
+from tests.conftest import RunLalamo
+
+
+def _language_model() -> LanguageModel:
+    model_dim = 8
+    context_length = 16
+    norm_config = NormalizationConfig(
+        epsilon=1e-5,
+        scale_offset=None,
+        upcast_mode=UpcastMode.ONLY_NORMALIZATION,
+        subtract_mean=False,
+    )
+    layer_config = TransformerLayerConfig(
+        pre_mixer_norm_config=norm_config,
+        mixer_config=AttentionConfig(
+            qkv_projection_config=LinearConfig(),
+            out_projection_config=LinearConfig(),
+            query_norm_config=None,
+            key_norm_config=None,
+            num_heads=2,
+            num_groups=2,
+            head_dim=4,
+            is_causal=True,
+            scale=None,
+            sliding_window_size=None,
+            logit_soft_cap=None,
+            has_sinks=False,
+            has_qkv_biases=False,
+            has_out_biases=False,
+        ),
+        post_mixer_norm_config=norm_config,
+        pre_mlp_norm_config=norm_config,
+        mlp_config=DenseMLPConfig(
+            linear_config=LinearConfig(),
+            activation=Identity(),
+            has_up_biases=False,
+            has_down_biases=False,
+            gate_clipping=None,
+            up_clipping=None,
+        ),
+        post_mlp_norm_config=norm_config,
+        rope_config=UnscaledRoPEConfig(
+            base=10_000.0,
+            max_sequence_length=context_length,
+            head_dim=4,
+        ),
+    )
+    config = LanguageModelConfig(
+        token_codec_config=ChatCodecConfig(
+            prompt_template="{{ messages[0]['content'] }}",
+            output_parser_regex=None,
+            system_role_name="system",
+            user_role_name="user",
+            assistant_role_name="assistant",
+            eos_token=None,
+            bos_token=None,
+        ),
+        decoder_config=DecoderConfig(
+            embedding_config=TiedEmbeddingConfig(
+                input_scale=None,
+                logit_soft_cap=None,
+            ),
+            transformer_config=TransformerConfig(
+                layer_configs=(layer_config,),
+                output_norm_config=norm_config,
+                model_dim=model_dim,
+                hidden_dim=16,
+            ),
+            vocab_size=32,
+        ),
+        generation_config=GenerationConfig(),
+    )
+    sharding_config = trace_sharding_config()
+    tokenizer = Tokenizer(WordLevel(vocab={"[UNK]": 0, "trace": 7}, unk_token="[UNK]"))
+    return config.init(
+        tokenizer,
+        RandomInitializer(
+            default_dtype=jnp.float32,
+            sharding_config=sharding_config,
+            key=jax.random.key(4),
+        ),
+    )
+
+
+def _assert_uzu_trace_paths(arrays: Mapping[str, jax.Array]) -> None:
+    assert "activation_trace.token_ids" in arrays
+    assert "activation_trace.token_positions" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.inputs" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.pre_mixer_norm" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.mixer" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.post_mixer_norm" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.mlp_inputs" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.pre_mlp_norm" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.mlp" in arrays
+    assert "activation_trace.layer_results.0.activation_trace.post_mlp_norm" in arrays
+    assert "activation_trace.layer_results.0.outputs" in arrays
+    assert "activation_trace.layer_results.0.updated_state.keys" in arrays
+    assert "activation_trace.layer_results.0.updated_state.values" in arrays
+    assert "activation_trace.output_norm" in arrays
+    assert "logits" in arrays
+
+
+def _assert_tokenization_trace(metadata: dict[str, str] | None, arrays: Mapping[str, jax.Array]) -> None:
+    assert metadata is not None
+    assert metadata["add_special_tokens"] == "false"
+    assert metadata["prompt_template"] == "{{ messages[0]['content'] }}"
+    assert metadata["rendered_request"] == "trace"
+    assert json.loads(metadata["request"]) == {
+        "add_generation_prompt": True,
+        "messages": [{"role": "user", "content": "trace"}],
+        "bos_token": None,
+        "eos_token": None,
+        "enable_thinking": True,
+    }
+    assert json.loads(metadata["tokens"]) == ["trace"]
+    assert arrays["activation_trace.token_ids"].tolist() == [[7]]
+    assert arrays["activation_trace.token_positions"].tolist() == [[0]]
+
+
+def _write_uzu_language_model(model: LanguageModel, model_dir: Path) -> None:
+    model_dir.mkdir(parents=True)
+    config = cast("dict[str, JSON]", model.config.to_json())
+    message_config = cast("dict[str, JSON]", config["token_codec_config"])
+    generation_config = cast("dict[str, JSON]", config["generation_config"])
+    uzu_config = {
+        "toolchain_version": "test",
+        "vendor": "test",
+        "family": "test",
+        "name": "test",
+        "size": "tiny",
+        "quantization": None,
+        "repo": "test",
+        "use_cases": [],
+        "model_type": "language_model",
+        "model_config": {
+            "model_config": config["decoder_config"],
+            "message_processor_config": {
+                "prompt_template": message_config["prompt_template"],
+                "output_parser_regex": message_config["output_parser_regex"],
+                "system_role_name": message_config["system_role_name"],
+                "user_role_name": message_config["user_role_name"],
+                "assistant_role_name": message_config["assistant_role_name"],
+                "eos_token": message_config["eos_token"],
+                "bos_token": message_config["bos_token"],
+                "default_system_prompt": message_config["default_system_prompt"],
+            },
+            "generation_config": {
+                "stop_token_ids": generation_config["stop_token_ids"],
+                "temperature": generation_config["temperature"],
+                "top_k": generation_config["top_k"],
+                "top_p": generation_config["top_p"],
+                "min_p": generation_config["min_p"],
+                "banned_tokens": generation_config["banned_tokens"],
+            },
+        },
+    }
+    with (model_dir / "config.json").open("w") as fd:
+        json.dump(uzu_config, fd, indent=4)
+    model.token_codec.tokenizer.save(str(model_dir / "tokenizer.json"))
+
+    arrays: dict[str, jax.Array] = {}
+    for path, array in model.export().arrays.items():
+        if path == "decoder.embedding.embedding.weights":
+            arrays["embedding.weights"] = array
+        elif path.startswith("decoder.transformer.ropes.0."):
+            arrays["transformer.global_rope." + path.removeprefix("decoder.transformer.ropes.0.")] = array
+        elif path.startswith("decoder."):
+            uzu_path = path.removeprefix("decoder.")
+            if uzu_path.endswith(".weights.weights"):
+                uzu_path = uzu_path.removesuffix(".weights")
+            arrays[uzu_path] = array
+
+    with (model_dir / "model.safetensors").open("wb") as fd:
+        safe_write(fd, arrays)
+
+
+def _write_token_trace(trace_path: Path) -> None:
+    _write_token_trace_arrays(
+        trace_path,
+        jnp.asarray([[0, 0, 0]], dtype=jnp.int32),
+        jnp.asarray([[0, 1, 2]], dtype=jnp.int32),
+    )
+
+
+def _write_token_trace_arrays(trace_path: Path, token_ids: jax.Array, token_positions: jax.Array) -> None:
+    with trace_path.open("wb") as fd:
+        safe_write(
+            fd,
+            {
+                "activation_trace.token_ids": token_ids,
+                "activation_trace.token_positions": token_positions,
+            },
+            metadata={"source": "fixture"},
+        )
+
+
+def test_record_message_trace_exports_uzu_trace_paths() -> None:
+    result = record_message_trace(_language_model(), [UserMessage("trace")])
+
+    arrays = export_trace_result(result)
+
+    _assert_uzu_trace_paths(arrays)
+    assert arrays["activation_trace.token_ids"].dtype == jnp.int32
+    assert arrays["activation_trace.token_ids"].shape == (1, 1)
+    assert arrays["logits"].dtype == arrays["activation_trace.output_norm"].dtype
+
+
+def test_record_tokenization_trace_exports_request_boundary() -> None:
+    trace_result = record_tokenization_trace(_language_model().token_codec, [UserMessage("trace")])
+
+    _assert_tokenization_trace(trace_result.metadata, trace_result.arrays)
+
+
+def test_load_traceable_model_loads_uzu_language_model(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    _write_uzu_language_model(_language_model(), model_dir)
+
+    result = record_message_trace(load_traceable_model(model_dir), [UserMessage("trace")])
+
+    _assert_uzu_trace_paths(export_trace_result(result))
+
+
+def test_load_traceable_token_codec_loads_uzu_language_model(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    _write_uzu_language_model(_language_model(), model_dir)
+
+    trace_result = record_tokenization_trace(load_traceable_token_codec(model_dir), [UserMessage("trace")])
+
+    _assert_tokenization_trace(trace_result.metadata, trace_result.arrays)
+
+
+def test_trace_command_writes_safetensors(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+
+    trace(model_dir, trace_path, [UserMessage("trace")])
+
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        _assert_uzu_trace_paths(arrays)
+        assert metadata is not None
+        assert metadata["rendered_request"] == "trace"
+
+
+def test_trace_command_writes_safetensors_for_uzu_model(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    trace_path = tmp_path / "traces.safetensors"
+    _write_uzu_language_model(_language_model(), model_dir)
+
+    trace(model_dir, trace_path, [UserMessage("trace")])
+
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        _assert_uzu_trace_paths(arrays)
+        assert metadata is not None
+        assert metadata["rendered_request"] == "trace"
+
+
+def test_trace_command_replays_token_trace(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    input_trace_path = tmp_path / "input-trace.safetensors"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+    _write_token_trace(input_trace_path)
+
+    trace(model_dir, trace_path, (), input_trace_path)
+
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        _assert_uzu_trace_paths(arrays)
+        assert metadata == {"source": "fixture"}
+        assert arrays["activation_trace.token_ids"].tolist() == [[0, 0, 0]]
+        assert arrays["activation_trace.token_positions"].tolist() == [[0, 1, 2]]
+
+
+def test_trace_command_rejects_bad_token_trace_shape(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    input_trace_path = tmp_path / "input-trace.safetensors"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+    with input_trace_path.open("wb") as fd:
+        safe_write(
+            fd,
+            {
+                "activation_trace.token_ids": jnp.asarray([0, 0, 0], dtype=jnp.int32),
+                "activation_trace.token_positions": jnp.asarray([0, 1, 2], dtype=jnp.int32),
+            },
+        )
+
+    with pytest.raises(ValueError, match=r"\[1, suffix_tokens\]"):
+        trace(model_dir, trace_path, (), input_trace_path)
+
+
+def test_trace_command_rejects_bad_token_trace_dtype(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    input_trace_path = tmp_path / "input-trace.safetensors"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+    with input_trace_path.open("wb") as fd:
+        safe_write(
+            fd,
+            {
+                "activation_trace.token_ids": jnp.asarray([[0, 0, 0]], dtype=jnp.uint32),
+                "activation_trace.token_positions": jnp.asarray([[0, 1, 2]], dtype=jnp.int32),
+            },
+        )
+
+    with pytest.raises(TypeError, match=r"token_ids.*int32"):
+        trace(model_dir, trace_path, (), input_trace_path)
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "token_positions", "message"),
+    (
+        (jnp.asarray([[-1]], dtype=jnp.int32), jnp.asarray([[0]], dtype=jnp.int32), r"token_ids.*\[0, 32\)"),
+        (jnp.asarray([[32]], dtype=jnp.int32), jnp.asarray([[0]], dtype=jnp.int32), r"token_ids.*\[0, 32\)"),
+        (jnp.asarray([[0]], dtype=jnp.int32), jnp.asarray([[-1]], dtype=jnp.int32), r"nonnegative"),
+        (jnp.asarray([[0]], dtype=jnp.int32), jnp.asarray([[16]], dtype=jnp.int32), r"positions.*\[0, 16\)"),
+    ),
+)
+def test_trace_command_rejects_bad_token_trace_values(
+    tmp_path: Path,
+    token_ids: jax.Array,
+    token_positions: jax.Array,
+    message: str,
+) -> None:
+    model_dir = tmp_path / "model"
+    input_trace_path = tmp_path / "input-trace.safetensors"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+    _write_token_trace_arrays(input_trace_path, token_ids, token_positions)
+
+    with pytest.raises(ValueError, match=message):
+        trace(model_dir, trace_path, (), input_trace_path)
+
+
+def test_trace_command_rejects_messages_with_input_trace(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    input_trace_path = tmp_path / "input-trace.safetensors"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+    _write_token_trace(input_trace_path)
+
+    with pytest.raises(ValueError, match="messages cannot be used"):
+        trace(model_dir, trace_path, [UserMessage("trace")], input_trace_path)
+
+
+def test_trace_command_replays_tokenization_trace(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    tokenization_trace_path = tmp_path / "tokenization-trace.safetensors"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+    trace_tokenization(model_dir, tokenization_trace_path, [UserMessage("trace")])
+
+    trace(model_dir, trace_path, (), tokenization_trace_path)
+
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        assert metadata is not None
+        assert metadata["rendered_request"] == "trace"
+        assert arrays["activation_trace.token_ids"].tolist() == [[7]]
+        assert arrays["activation_trace.token_positions"].tolist() == [[0]]
+
+
+def test_record_tokenization_trace_rejects_empty_encoding() -> None:
+    token_codec = ChatCodecConfig(
+        prompt_template="",
+        output_parser_regex=None,
+        system_role_name="system",
+        user_role_name="user",
+        assistant_role_name="assistant",
+        eos_token=None,
+        bos_token=None,
+    ).init(Tokenizer(WordLevel(vocab={"[UNK]": 0}, unk_token="[UNK]")))
+
+    with pytest.raises(ValueError, match="at least one token"):
+        record_tokenization_trace(token_codec, [UserMessage("trace")])
+
+
+def test_trace_tokenization_command_writes_safetensors(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    trace_path = tmp_path / "tokenization-trace.safetensors"
+    _language_model().save(model_dir)
+
+    trace_tokenization(model_dir, trace_path, [UserMessage("trace")])
+
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        _assert_tokenization_trace(metadata, arrays)
+
+
+def test_trace_cli_writes_safetensors(tmp_path: Path, run_lalamo: RunLalamo) -> None:
+    model_dir = tmp_path / "model"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+
+    run_lalamo("trace", str(model_dir), "--output-path", str(trace_path), "--message", "trace")
+
+    with trace_path.open("rb") as fd:
+        _, arrays = safe_read(fd)
+        _assert_uzu_trace_paths(arrays)
+
+
+def test_trace_cli_replays_token_trace(tmp_path: Path, run_lalamo: RunLalamo) -> None:
+    model_dir = tmp_path / "model"
+    input_trace_path = tmp_path / "input-trace.safetensors"
+    trace_path = tmp_path / "traces.safetensors"
+    _language_model().save(model_dir)
+    _write_token_trace(input_trace_path)
+
+    run_lalamo(
+        "trace",
+        str(model_dir),
+        "--output-path",
+        str(trace_path),
+        "--input-trace-path",
+        str(input_trace_path),
+    )
+
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        assert metadata == {"source": "fixture"}
+        assert arrays["activation_trace.token_ids"].tolist() == [[0, 0, 0]]
+
+
+def test_trace_tokenization_cli_writes_safetensors(tmp_path: Path, run_lalamo: RunLalamo) -> None:
+    model_dir = tmp_path / "model"
+    trace_path = tmp_path / "tokenization-trace.safetensors"
+    _language_model().save(model_dir)
+
+    run_lalamo("trace-tokenization", str(model_dir), "--output-path", str(trace_path), "--message", "trace")
+
+    with trace_path.open("rb") as fd:
+        metadata, arrays = safe_read(fd)
+        _assert_tokenization_trace(metadata, arrays)


### PR DESCRIPTION
## Summary

Adds the Lalamo side of the unified tracing flow:

- activation trace export for Lalamo models
- tokenization trace export with replay-compatible token arrays
- Hugging Face reference trace export for tracer tests
- standalone `compare-traces` command for two `traces.safetensors` files
- stricter comparator behavior for missing reference arrays, tiny tensors, dtype/shape mismatches, and non-finite values

This is intended to make Lalamo the shared place for trace comparison while each runtime only exports activations/tokenization into the shared safetensors schema.

Companion Uzu PR: https://github.com/trymirai/uzu/pull/450

## Validation

- `uv run --no-dev --extra cpu --with pytest pytest tests/unit/test_tracer.py tests/unit/test_trace_comparator.py`
- `uv run --no-dev --extra cpu --with ruff ruff check lalamo/commands.py lalamo/main.py lalamo/model_import/model_configs/huggingface/modern_bert.py lalamo/model_import/model_specs/qwen.py lalamo/tracer.py lalamo/trace_comparator.py tests/tracer/test_huggingface_models.py tests/tracer/tracer.py tests/tracer/tracer_huggingface.py tests/unit/test_tracer.py tests/unit/test_trace_comparator.py`
- `git diff --check`