### PR TITLE
Fix cross-layer KV cache sharing (Gemma4)

### DIFF
--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -739,6 +739,7 @@ def load_attention(
     implementation: CompressionImplementation = CompressionImplementation.INFERENCE,
     reorder_q_proj_gate: bool = True,
 ) -> Attention:
+    qkv_sublayers = ["q_proj"] if module.config.is_kv_sharing else ["q_proj", "k_proj", "v_proj"]
     if module.gate_projection is not None:
         num_heads, head_dim = module.config.num_heads, module.config.head_dim
         q_overrides, gate_weights = _extract_gate_weights(
@@ -753,7 +754,7 @@ def load_attention(
             module.qkv_projection,
             {**weights_dict, **q_overrides},
             path,
-            sublayers_to_fuse=["q_proj", "k_proj", "v_proj"],
+            sublayers_to_fuse=qkv_sublayers,
             implementation=implementation,
         )
 
@@ -768,7 +769,7 @@ def load_attention(
             module.qkv_projection,
             weights_dict,
             path,
-            sublayers_to_fuse=["q_proj", "k_proj", "v_proj"],
+            sublayers_to_fuse=qkv_sublayers,
             implementation=implementation,
         )
         gate_projection = None

--- a/lalamo/model_import/model_configs/huggingface/gemma4.py
+++ b/lalamo/model_import/model_configs/huggingface/gemma4.py
@@ -193,6 +193,7 @@ class HFGemma4TextConfig:
                 scale=1.0,
                 sliding_window_size=sliding_window_size,
                 normalize_values=True,
+                is_kv_sharing=not owns_kv_cache,
             )
 
             transformer_layer_config = TransformerLayerConfig(

--- a/lalamo/modules/token_mixer.py
+++ b/lalamo/modules/token_mixer.py
@@ -141,6 +141,7 @@ class TokenMixerBase[ConfigT: TokenMixerConfig, StateLayerT: StateLayerBase](Lal
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
+        reuse_cache: bool = False,
         *,
         keychain: Keychain,
     ) -> TokenMixerResult[StateLayerT]: ...

--- a/lalamo/modules/token_mixers/attention.py
+++ b/lalamo/modules/token_mixers/attention.py
@@ -336,6 +336,7 @@ class AttentionConfig(TokenMixerConfig):
     gate_projection_config: LinearConfig | None = None
     # Scale-free RMS normalization on values
     normalize_values: bool = False
+    is_kv_sharing: bool = False
 
     def init(
         self,
@@ -343,11 +344,14 @@ class AttentionConfig(TokenMixerConfig):
         model_dim: int,
     ) -> "Attention":
         q_output_dim = self.num_heads * self.head_dim
-        output_dims = (
-            q_output_dim,
-            self.num_groups * self.head_dim,
-            self.num_groups * self.head_dim,
-        )
+        if self.is_kv_sharing:
+            output_dims = (q_output_dim,)
+        else:
+            output_dims = (
+                q_output_dim,
+                self.num_groups * self.head_dim,
+                self.num_groups * self.head_dim,
+            )
         qkv_projection = self.qkv_projection_config.init(
             initializer,
             input_dim=model_dim,
@@ -379,7 +383,7 @@ class AttentionConfig(TokenMixerConfig):
         else:
             query_norm = None
 
-        if self.key_norm_config is not None:
+        if self.key_norm_config is not None and not self.is_kv_sharing:
             key_norm = self.key_norm_config.init(
                 initializer,
                 input_dim=self.head_dim,
@@ -475,12 +479,17 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
         keychain: Keychain,
     ) -> AttentionResult:
         qkv_keychain, gate_keychain, out_keychain = keychain.split(3)
-        queries, keys, values = call_vmapped(
+        assert reuse_cache == self.config.is_kv_sharing, "reuse_cache must match AttentionConfig.is_kv_sharing"
+        projections = call_vmapped(
             self.qkv_projection,
             inputs,
             forward_pass_config=forward_pass_config.matmul_config,
             keychain=qkv_keychain,
         )
+        if self.config.is_kv_sharing:
+            (queries,) = projections
+        else:
+            queries, keys, values = projections
         if self.gate_projection is not None:
             (gate,) = call_vmapped(
                 self.gate_projection,
@@ -495,12 +504,14 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
             queries, self.config.num_heads, self.query_norm, positional_embeddings, forward_pass_config
         )
 
-        prefix_length = 0 if state is None else state.current_prefix_length()
+        num_suffix_tokens, _, _ = queries.shape
         if reuse_cache:
             if state is None:
                 raise ValueError("a KV-sharing layer must receive the source layer's cache as `state`")
+            prefix_length = state.current_prefix_length() - num_suffix_tokens
             updated_state = state
         else:
+            prefix_length = 0 if state is None else state.current_prefix_length()
             keys = self._prepare_heads(
                 keys, self.config.num_groups, self.key_norm, positional_embeddings, forward_pass_config
             )
@@ -524,7 +535,6 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
                 updated_state = state.extend(keys, values, added_length=length_without_padding)
 
         queries = queries.astype(updated_state.keys.dtype)
-        num_suffix_tokens, _, _ = queries.shape
         if attention_parent_indices is not None:
             mask = updated_state.tree_attention_mask(prefix_length, attention_parent_indices)
         else:

--- a/lalamo/modules/token_mixers/attention.py
+++ b/lalamo/modules/token_mixers/attention.py
@@ -486,10 +486,7 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
             forward_pass_config=forward_pass_config.matmul_config,
             keychain=qkv_keychain,
         )
-        if self.config.is_kv_sharing:
-            (queries,) = projections
-        else:
-            queries, keys, values = projections
+        queries = projections[0]
         if self.gate_projection is not None:
             (gate,) = call_vmapped(
                 self.gate_projection,
@@ -511,6 +508,7 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
             prefix_length = state.current_prefix_length() - num_suffix_tokens
             updated_state = state
         else:
+            _, keys, values = projections
             prefix_length = 0 if state is None else state.current_prefix_length()
             keys = self._prepare_heads(
                 keys, self.config.num_groups, self.key_norm, positional_embeddings, forward_pass_config

--- a/lalamo/modules/token_mixers/attention.py
+++ b/lalamo/modules/token_mixers/attention.py
@@ -437,6 +437,30 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
         return self.sinks is not None
 
     @eqx.filter_jit
+    def _prepare_heads(
+        self,
+        projection: Float[Array, "tokens channels"],
+        num_heads: int,
+        norm: Normalization | None,
+        positional_embeddings: PositionalEmbeddings | None,
+        forward_pass_config: MixerForwardPassConfig,
+    ) -> Float[Array, "tokens heads head_channels"]:
+        heads = rearrange(
+            projection,
+            "tokens (heads head_channels) -> tokens heads head_channels",
+            heads=num_heads,
+            head_channels=self.config.head_dim,
+        )
+        if norm is not None:
+            heads = call_vmapped_twice(
+                norm,
+                heads,
+                forward_pass_config=forward_pass_config.normalization_forward_pass_config,
+            )
+        if positional_embeddings is not None:
+            heads = call_vmapped(positional_embeddings.apply, heads, in_axes=1, out_axes=1)
+        return heads
+
     def __call__(
         self,
         inputs: Float[Array, "suffix_tokens channels"],
@@ -446,6 +470,7 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
+        reuse_cache: bool = False,
         *,
         keychain: Keychain,
     ) -> AttentionResult:
@@ -466,57 +491,37 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
         else:
             gate = None
 
-        queries = rearrange(
-            queries,
-            "tokens (heads head_channels) -> tokens heads head_channels",
-            heads=self.config.num_heads,
-            head_channels=self.config.head_dim,
+        queries = self._prepare_heads(
+            queries, self.config.num_heads, self.query_norm, positional_embeddings, forward_pass_config
         )
-        keys = rearrange(
-            keys,
-            "tokens (groups head_channels) -> tokens groups head_channels",
-            groups=self.config.num_groups,
-            head_channels=self.config.head_dim,
-        )
-        values = rearrange(
-            values,
-            "tokens (groups head_channels) -> tokens groups head_channels",
-            groups=self.config.num_groups,
-            head_channels=self.config.head_dim,
-        )
-        if self.query_norm is not None:
-            queries = call_vmapped_twice(
-                self.query_norm,
-                queries,
-                forward_pass_config=forward_pass_config.normalization_forward_pass_config,
-            )
-        if self.key_norm is not None:
-            keys = call_vmapped_twice(
-                self.key_norm,
-                keys,
-                forward_pass_config=forward_pass_config.normalization_forward_pass_config,
-            )
-        if self.config.normalize_values:
-            values = _rms_normalize(
-                values,
-                eps=1e-6,
-                forward_pass_config=forward_pass_config.normalization_forward_pass_config,
-            )
-
-        if positional_embeddings is not None:
-            queries = call_vmapped(positional_embeddings.apply, queries, in_axes=1, out_axes=1)
-            keys = call_vmapped(positional_embeddings.apply, keys, in_axes=1, out_axes=1)
 
         prefix_length = 0 if state is None else state.current_prefix_length()
-        if state is None:
-            updated_state = DynamicKVCacheLayer.init(
-                self.has_sinks,
-                keys.astype(values.dtype),
-                values,
-                length=length_without_padding,
-            )
+        if reuse_cache:
+            if state is None:
+                raise ValueError("a KV-sharing layer must receive the source layer's cache as `state`")
+            updated_state = state
         else:
-            updated_state = state.extend(keys, values, added_length=length_without_padding)
+            keys = self._prepare_heads(
+                keys, self.config.num_groups, self.key_norm, positional_embeddings, forward_pass_config
+            )
+            values = rearrange(
+                values,
+                "tokens (groups head_channels) -> tokens groups head_channels",
+                groups=self.config.num_groups,
+                head_channels=self.config.head_dim,
+            )
+            if self.config.normalize_values:
+                values = _rms_normalize(
+                    values,
+                    eps=1e-6,
+                    forward_pass_config=forward_pass_config.normalization_forward_pass_config,
+                )
+            if state is None:
+                updated_state = DynamicKVCacheLayer.init(
+                    self.has_sinks, keys.astype(values.dtype), values, length=length_without_padding
+                )
+            else:
+                updated_state = state.extend(keys, values, added_length=length_without_padding)
 
         queries = queries.astype(updated_state.keys.dtype)
         num_suffix_tokens, _, _ = queries.shape

--- a/lalamo/modules/token_mixers/deltanet.py
+++ b/lalamo/modules/token_mixers/deltanet.py
@@ -409,6 +409,7 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
+        reuse_cache: bool = False,  # unused; KV sharing only applies to attention
         *,
         keychain: Keychain,
     ) -> DeltaNetResult:

--- a/lalamo/modules/token_mixers/deltanet.py
+++ b/lalamo/modules/token_mixers/deltanet.py
@@ -409,7 +409,7 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
-        reuse_cache: bool = False,  # unused; KV sharing only applies to attention
+        reuse_cache: bool = False,
         *,
         keychain: Keychain,
     ) -> DeltaNetResult:
@@ -417,6 +417,8 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
             raise ValueError("Positional embeddings are not supported for DeltaNet.")
         if attention_parent_indices is not None:
             raise ValueError("Attention parent indices are not supported for DeltaNet.")
+        if reuse_cache:
+            raise ValueError("KV cache sharing is not supported for DeltaNet.")
 
         in_keychain, out_keychain = keychain.split()
         num_tokens, *_ = inputs.shape

--- a/lalamo/modules/token_mixers/mamba.py
+++ b/lalamo/modules/token_mixers/mamba.py
@@ -592,6 +592,7 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
+        reuse_cache: bool = False,  # unused; KV sharing only applies to attention
         precision: DTypeLike = jnp.float32,
         *,
         keychain: Keychain,

--- a/lalamo/modules/token_mixers/mamba.py
+++ b/lalamo/modules/token_mixers/mamba.py
@@ -592,7 +592,7 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
-        reuse_cache: bool = False,  # unused; KV sharing only applies to attention
+        reuse_cache: bool = False,
         precision: DTypeLike = jnp.float32,
         *,
         keychain: Keychain,
@@ -601,6 +601,8 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
             raise ValueError("Positional embeddings are not supported for Mamba2.")
         if attention_parent_indices is not None:
             raise ValueError("Attention parent indices are not supported for Mamba2.")
+        if reuse_cache:
+            raise ValueError("KV cache sharing is not supported for Mamba2.")
 
         if state is None:
             state = SSMStateLayer.init(

--- a/lalamo/modules/token_mixers/short_conv.py
+++ b/lalamo/modules/token_mixers/short_conv.py
@@ -109,6 +109,7 @@ class ShortConv(TokenMixerBase[ShortConvConfig, ShortConvStateLayer]):
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
+        reuse_cache: bool = False,  # unused; KV sharing only applies to attention
         *,
         keychain: Keychain,
     ) -> TokenMixerResult[ShortConvStateLayer]:

--- a/lalamo/modules/token_mixers/short_conv.py
+++ b/lalamo/modules/token_mixers/short_conv.py
@@ -109,7 +109,7 @@ class ShortConv(TokenMixerBase[ShortConvConfig, ShortConvStateLayer]):
         length_without_padding: Int[Array, ""] | int | None = None,
         forward_pass_config: MixerForwardPassConfig = MixerForwardPassConfig(),
         attention_parent_indices: Int[Array, " suffix_tokens"] | None = None,
-        reuse_cache: bool = False,  # unused; KV sharing only applies to attention
+        reuse_cache: bool = False,
         *,
         keychain: Keychain,
     ) -> TokenMixerResult[ShortConvStateLayer]:
@@ -117,6 +117,8 @@ class ShortConv(TokenMixerBase[ShortConvConfig, ShortConvStateLayer]):
             raise ValueError("Positional embeddings are not supported for ShortConv.")
         if attention_parent_indices is not None:
             raise ValueError("Attention parent indices are not supported for ShortConv.")
+        if reuse_cache:
+            raise ValueError("KV cache sharing is not supported for ShortConv.")
 
         in_keychain, out_keychain = keychain.split()
         pre_conv_gate, post_conv_gate, x = call_vmapped(

--- a/lalamo/modules/transformer_layer.py
+++ b/lalamo/modules/transformer_layer.py
@@ -269,6 +269,7 @@ class TransformerLayer(LalamoModule[TransformerLayerConfig]):
                 length_without_padding=length_without_padding,
                 forward_pass_config=forward_pass_config.mixer_forward_pass_config,
                 attention_parent_indices=parent_indices,
+                reuse_cache=self.config.kv_source_layer_index is not None,
                 keychain=keychain,
             )
 

--- a/tests/unit/test_tree_attention.py
+++ b/tests/unit/test_tree_attention.py
@@ -23,7 +23,7 @@ from lalamo.modules import (
     UnscaledRoPEConfig,
     UpcastMode,
 )
-from lalamo.modules.token_mixers.attention import AttentionConfig
+from lalamo.modules.token_mixers.attention import Attention, AttentionConfig
 from lalamo.modules.token_mixers.kv_cache import build_tree_attention_mask, tree_ancestor_mask
 from lalamo.utils.sharding import ShardingConfig
 from tests.common import assert_close
@@ -220,9 +220,13 @@ def test_tree_attention_matches_sequential_chain(decoder: Decoder) -> None:
 
 @pytest.mark.parametrize("decoder", [(None, 0)], indirect=True, ids=["shared_kv"])
 def test_kv_sharing_layer_projects_queries_only(decoder: Decoder) -> None:
-    assert decoder.transformer.layers[0].mixer.qkv_projection.output_dims == (8, 8, 8)
-    assert decoder.transformer.layers[1].mixer.qkv_projection.output_dims == (8,)
-    assert decoder.transformer.layers[1].mixer.key_norm is None
+    owner = decoder.transformer.layers[0].mixer
+    shared = decoder.transformer.layers[1].mixer
+    assert isinstance(owner, Attention)
+    assert isinstance(shared, Attention)
+    assert owner.qkv_projection.output_dims == (8, 8, 8)
+    assert shared.qkv_projection.output_dims == (8,)
+    assert shared.key_norm is None
 
 
 def test_tree_attention_sibling_isolation(decoder: Decoder) -> None:

--- a/tests/unit/test_tree_attention.py
+++ b/tests/unit/test_tree_attention.py
@@ -30,8 +30,7 @@ from tests.common import assert_close
 from tests.helpers import make_test_sharding_config
 
 
-@pytest.fixture
-def decoder() -> Decoder:
+def build_decoder(kv_source_layer_indices: tuple[int | None, ...] = (None,)) -> Decoder:
     precision = jnp.float32
     model_dim = 8
     hidden_dim = 16
@@ -43,22 +42,6 @@ def decoder() -> Decoder:
         scale_offset=None,
         upcast_mode=UpcastMode.ONLY_NORMALIZATION,
         subtract_mean=False,
-    )
-    attention_config = AttentionConfig(
-        qkv_projection_config=LinearConfig(),
-        out_projection_config=LinearConfig(),
-        query_norm_config=None,
-        key_norm_config=None,
-        num_heads=2,
-        num_groups=2,
-        head_dim=4,
-        is_causal=True,
-        scale=None,
-        sliding_window_size=None,
-        logit_soft_cap=None,
-        has_sinks=False,
-        has_qkv_biases=False,
-        has_out_biases=False,
     )
     mlp_config = DenseMLPConfig(
         linear_config=LinearConfig(),
@@ -73,17 +56,41 @@ def decoder() -> Decoder:
         max_sequence_length=context_length,
         head_dim=4,
     )
-    layer_config = TransformerLayerConfig(
-        pre_mixer_norm_config=norm_config,
-        mixer_config=attention_config,
-        post_mixer_norm_config=None,
-        pre_mlp_norm_config=norm_config,
-        mlp_config=mlp_config,
-        post_mlp_norm_config=None,
-        rope_config=rope_config,
-    )
+
+    layer_configs = []
+    for kv_source in kv_source_layer_indices:
+        attention_config = AttentionConfig(
+            qkv_projection_config=LinearConfig(),
+            out_projection_config=LinearConfig(),
+            query_norm_config=None,
+            key_norm_config=None,
+            num_heads=2,
+            num_groups=2,
+            head_dim=4,
+            is_causal=True,
+            scale=None,
+            sliding_window_size=None,
+            logit_soft_cap=None,
+            has_sinks=False,
+            has_qkv_biases=False,
+            has_out_biases=False,
+            is_kv_sharing=kv_source is not None,
+        )
+        layer_configs.append(
+            TransformerLayerConfig(
+                pre_mixer_norm_config=norm_config,
+                mixer_config=attention_config,
+                post_mixer_norm_config=None,
+                pre_mlp_norm_config=norm_config,
+                mlp_config=mlp_config,
+                post_mlp_norm_config=None,
+                rope_config=rope_config,
+                kv_source_layer_index=kv_source,
+            )
+        )
+
     transformer_config = TransformerConfig(
-        layer_configs=(layer_config,),
+        layer_configs=tuple(layer_configs),
         output_norm_config=norm_config,
         model_dim=model_dim,
         hidden_dim=hidden_dim,
@@ -156,7 +163,9 @@ def test_build_tree_attention_mask_prefix_plus_draft() -> None:
     assert jnp.array_equal(mask, expected)
 
 
-def test_tree_attention_matches_sequential_chain(decoder: Decoder) -> None:
+@pytest.mark.parametrize("kv_source_layer_indices", [(None,), (None, 0)], ids=["plain", "shared_kv"])
+def test_tree_attention_matches_sequential_chain(kv_source_layer_indices: tuple[int | None, ...]) -> None:
+    decoder = build_decoder(kv_source_layer_indices)
     prefix_token_ids = jnp.array([[1, 2, 3]], dtype=jnp.int32)
     prefix_positions = jnp.array([[0, 1, 2]], dtype=jnp.int32)
     chain_token_ids = jnp.array([4, 5, 6], dtype=jnp.int32)
@@ -201,7 +210,6 @@ def test_tree_attention_matches_sequential_chain(decoder: Decoder) -> None:
         forward_pass_config=single_token_forward_pass_config,
         keychain=Keychain.init(30, sharding_config=make_test_sharding_config()),
     )
-
     assert_close(
         result=tree_result.logits[0],
         reference=jnp.stack(sequential_logits),
@@ -209,7 +217,15 @@ def test_tree_attention_matches_sequential_chain(decoder: Decoder) -> None:
     )
 
 
-def test_tree_attention_sibling_isolation(decoder: Decoder) -> None:
+def test_kv_sharing_layer_projects_queries_only() -> None:
+    decoder = build_decoder(kv_source_layer_indices=(None, 0))
+    assert decoder.transformer.layers[0].mixer.qkv_projection.output_dims == (8, 8, 8)
+    assert decoder.transformer.layers[1].mixer.qkv_projection.output_dims == (8,)
+    assert decoder.transformer.layers[1].mixer.key_norm is None
+
+
+def test_tree_attention_sibling_isolation() -> None:
+    decoder = build_decoder()
     prefix_token_ids = jnp.array([[1, 2]], dtype=jnp.int32)
     prefix_positions = jnp.array([[0, 1]], dtype=jnp.int32)
 

--- a/tests/unit/test_tree_attention.py
+++ b/tests/unit/test_tree_attention.py
@@ -30,7 +30,9 @@ from tests.common import assert_close
 from tests.helpers import make_test_sharding_config
 
 
-def build_decoder(kv_source_layer_indices: tuple[int | None, ...] = (None,)) -> Decoder:
+@pytest.fixture
+def decoder(request: pytest.FixtureRequest) -> Decoder:
+    kv_source_layer_indices: tuple[int | None, ...] = getattr(request, "param", (None,))
     precision = jnp.float32
     model_dim = 8
     hidden_dim = 16
@@ -163,9 +165,8 @@ def test_build_tree_attention_mask_prefix_plus_draft() -> None:
     assert jnp.array_equal(mask, expected)
 
 
-@pytest.mark.parametrize("kv_source_layer_indices", [(None,), (None, 0)], ids=["plain", "shared_kv"])
-def test_tree_attention_matches_sequential_chain(kv_source_layer_indices: tuple[int | None, ...]) -> None:
-    decoder = build_decoder(kv_source_layer_indices)
+@pytest.mark.parametrize("decoder", [(None,), (None, 0)], indirect=True, ids=["plain", "shared_kv"])
+def test_tree_attention_matches_sequential_chain(decoder: Decoder) -> None:
     prefix_token_ids = jnp.array([[1, 2, 3]], dtype=jnp.int32)
     prefix_positions = jnp.array([[0, 1, 2]], dtype=jnp.int32)
     chain_token_ids = jnp.array([4, 5, 6], dtype=jnp.int32)
@@ -217,15 +218,14 @@ def test_tree_attention_matches_sequential_chain(kv_source_layer_indices: tuple[
     )
 
 
-def test_kv_sharing_layer_projects_queries_only() -> None:
-    decoder = build_decoder(kv_source_layer_indices=(None, 0))
+@pytest.mark.parametrize("decoder", [(None, 0)], indirect=True, ids=["shared_kv"])
+def test_kv_sharing_layer_projects_queries_only(decoder: Decoder) -> None:
     assert decoder.transformer.layers[0].mixer.qkv_projection.output_dims == (8, 8, 8)
     assert decoder.transformer.layers[1].mixer.qkv_projection.output_dims == (8,)
     assert decoder.transformer.layers[1].mixer.key_norm is None
 
 
-def test_tree_attention_sibling_isolation() -> None:
-    decoder = build_decoder()
+def test_tree_attention_sibling_isolation(decoder: Decoder) -> None:
     prefix_token_ids = jnp.array([[1, 2]], dtype=jnp.int32)
     prefix_positions = jnp.array([[0, 1]], dtype=jnp.int32)
 


### PR DESCRIPTION
**What was wrong:** KV-sharing layers didn't reuse the source cache verbatim, they ran the full QKV projection and used the post-append length as the prefix boundary. So queries attended to their own keys (HF never does), and at prefill attended non-causally to future tokens, wrong outputs vs HF.

**Now:** sharing layers reuse the source cache as-is and project queries only
  (skip K/V projection, key norm, RoPE, cache write), using the original prefix
  length for the tree/spec mask. Matches HF.

  **Tests:** added shared-KV coverage to `test_tree_attention.py`, tree == sequential decode for a 2-layer shared model, plus a Q-only projection check.