### PR TITLE
Many precision fixes and proper weak typing of initializers

### DIFF
--- a/lalamo/commands.py
+++ b/lalamo/commands.py
@@ -169,10 +169,11 @@ def convert(
         ConversionCallbacks,
     ] = ConversionCallbacks,
 ) -> None:
+    effective_dtype = dtype or DType.BFLOAT16
     callbacks = callbacks_type(
         model_spec,
         output_dir,
-        dtype,
+        effective_dtype,
         context_length,
     )
 
@@ -192,14 +193,10 @@ def convert(
             case FinishedInitializingModelEvent():
                 callbacks.finished_initializing_model()
 
-    import_dtype = None
-    if dtype is not None:
-        import_dtype = jnp.dtype(dtype.value)
-
     imported_model = import_model(
         model_spec,
         sharding_config=ShardingConfig.replicated(),
-        dtype=import_dtype,
+        dtype=jnp.dtype(effective_dtype.value),
         context_length=context_length,
         progress_callback=progress_callback,
     )

--- a/lalamo/compressed/data/lloyd_max.py
+++ b/lalamo/compressed/data/lloyd_max.py
@@ -121,7 +121,8 @@ def _sample_values_to_lloyd_lut_values(
         sorted_weights = weights[sorted_indices]
         cumulative_weights = jnp.cumsum(sorted_weights)
         total_weight = cumulative_weights[-1]
-        center_weight_targets = (jnp.arange(num_levels) + 0.5) * total_weight / num_levels
+        level_positions = jnp.arange(num_levels, dtype=values.dtype) + jnp.asarray(0.5, dtype=values.dtype)
+        center_weight_targets = level_positions * total_weight / jnp.asarray(num_levels, dtype=values.dtype)
         center_indices = jnp.searchsorted(cumulative_weights, center_weight_targets, side="left", method="compare_all")
         center_indices = jnp.minimum(center_indices, values.size - 1)
         centers = sorted_values[center_indices]

--- a/lalamo/compressed/int.py
+++ b/lalamo/compressed/int.py
@@ -424,7 +424,6 @@ class IntMatrix(EmbeddingMatrix[IntSpec]):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> "IntMatrix": ...
@@ -561,7 +560,6 @@ class IntMatrixForTraining(IntMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> IntMatrix:
@@ -575,19 +573,16 @@ class IntMatrixForTraining(IntMatrix):
         packed_weights = load_as(
             self._packed_quantized_weights,
             exported_data.arrays[prefix / "weights"],
-            allow_dtype_cast=False,
         )
         scales = load_as(
             self.scales,
             exported_data.arrays[prefix / "scales"],
-            allow_dtype_cast=allow_dtype_cast,
         )
         packed_zero_points = self._packed_quantized_zero_points
         if packed_zero_points is not None:
             packed_zero_points = load_as(
                 packed_zero_points,
                 exported_data.arrays[prefix / "zero_points"],
-                allow_dtype_cast=False,
             )
         return self.spec.from_packed_parameters(
             packed_weights=packed_weights,
@@ -646,7 +641,6 @@ class IntMatrixForInference(IntMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> IntMatrix:
@@ -660,19 +654,16 @@ class IntMatrixForInference(IntMatrix):
         packed_weights = load_as(
             self.packed_weights,
             exported_data.arrays[prefix / "weights"],
-            allow_dtype_cast=False,
         )
         scales = load_as(
             self.scales,
             exported_data.arrays[prefix / "scales"],
-            allow_dtype_cast=allow_dtype_cast,
         )
         packed_zero_points = self._packed_quantized_zero_points
         if packed_zero_points is not None:
             packed_zero_points = load_as(
                 packed_zero_points,
                 exported_data.arrays[prefix / "zero_points"],
-                allow_dtype_cast=False,
             )
         return IntMatrixForInference(
             spec=self.spec,

--- a/lalamo/compressed/lloyd_max.py
+++ b/lalamo/compressed/lloyd_max.py
@@ -627,7 +627,6 @@ class LloydMaxMatrix(EmbeddingMatrix[LloydMaxSpec]):
     def _load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,  # noqa: ARG002
         *,
         implementation: CompressionImplementation,
         prefix: ParameterPath | None = None,
@@ -644,17 +643,14 @@ class LloydMaxMatrix(EmbeddingMatrix[LloydMaxSpec]):
             packed_bias_indices = load_as(
                 self._packed_bias_indices,
                 exported_data.arrays[prefix / "bias_indices"],
-                allow_dtype_cast=False,
             )
         packed_weight_indices = load_as(
             self._packed_weight_indices,
             exported_data.arrays[prefix / "weights"],
-            allow_dtype_cast=False,
         )
         packed_scales = load_as(
             self._packed_scales,
             exported_data.arrays[prefix / "scales"],
-            allow_dtype_cast=False,
         )
         if implementation == CompressionImplementation.INFERENCE:
             return LloydMaxMatrixForInference(
@@ -691,7 +687,6 @@ class LloydMaxMatrix(EmbeddingMatrix[LloydMaxSpec]):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> "LloydMaxMatrix": ...
@@ -809,13 +804,11 @@ class LloydMaxMatrixForTraining(LloydMaxMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> LloydMaxMatrix:
         return self._load_exported(
             exported_data,
-            allow_dtype_cast=allow_dtype_cast,
             implementation=CompressionImplementation.TRAINING,
             prefix=prefix,
         )
@@ -912,13 +905,11 @@ class LloydMaxMatrixForInference(LloydMaxMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> LloydMaxMatrix:
         return self._load_exported(
             exported_data,
-            allow_dtype_cast=allow_dtype_cast,
             implementation=CompressionImplementation.INFERENCE,
             prefix=prefix,
         )

--- a/lalamo/compressed/microfloat.py
+++ b/lalamo/compressed/microfloat.py
@@ -404,7 +404,6 @@ class MicrofloatMatrix(EmbeddingMatrix[MicrofloatSpec]):
     def _load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         implementation: CompressionImplementation,
         prefix: ParameterPath | None = None,
@@ -417,13 +416,11 @@ class MicrofloatMatrix(EmbeddingMatrix[MicrofloatSpec]):
         packed_weights = load_as(
             self._packed_weights,
             exported_data.arrays[prefix / "weights"],
-            allow_dtype_cast=False,
         )
-        packed_scales = load_as(self._packed_scales, exported_data.arrays[prefix / "scales"], allow_dtype_cast=False)
+        packed_scales = load_as(self._packed_scales, exported_data.arrays[prefix / "scales"])
         global_scale = load_as(
             self.global_scale,
             exported_data.arrays[prefix / "global_scale"],
-            allow_dtype_cast=allow_dtype_cast,
         )
         if implementation == CompressionImplementation.INFERENCE:
             return MicrofloatMatrixForInference(
@@ -460,7 +457,6 @@ class MicrofloatMatrix(EmbeddingMatrix[MicrofloatSpec]):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> "MicrofloatMatrix": ...
@@ -559,13 +555,11 @@ class MicrofloatMatrixForTraining(MicrofloatMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> MicrofloatMatrix:
         return self._load_exported(
             exported_data,
-            allow_dtype_cast=allow_dtype_cast,
             implementation=CompressionImplementation.TRAINING,
             prefix=prefix,
         )
@@ -654,13 +648,11 @@ class MicrofloatMatrixForInference(MicrofloatMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> MicrofloatMatrix:
         return self._load_exported(
             exported_data,
-            allow_dtype_cast=allow_dtype_cast,
             implementation=CompressionImplementation.INFERENCE,
             prefix=prefix,
         )

--- a/lalamo/compressed/mlx.py
+++ b/lalamo/compressed/mlx.py
@@ -271,7 +271,6 @@ class MLXMatrix(EmbeddingMatrix[MLXSpec]):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> "MLXMatrix": ...
@@ -386,7 +385,6 @@ class MLXMatrixForTraining(MLXMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> MLXMatrix:
@@ -400,17 +398,14 @@ class MLXMatrixForTraining(MLXMatrix):
         packed_weights = load_as(
             self._packed_quantized_weights,
             exported_data.arrays[prefix / "weights"],
-            allow_dtype_cast=False,
         )
         scales = load_as(
             self.scales,
             exported_data.arrays[prefix / "scales"],
-            allow_dtype_cast=allow_dtype_cast,
         )
         biases = load_as(
             self.biases,
             exported_data.arrays[prefix / "biases"],
-            allow_dtype_cast=allow_dtype_cast,
         )
         return self.spec.from_packed_parameters(
             packed_weights=packed_weights,
@@ -465,7 +460,6 @@ class MLXMatrixForInference(MLXMatrix):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> MLXMatrix:
@@ -479,17 +473,14 @@ class MLXMatrixForInference(MLXMatrix):
         packed_weights = load_as(
             self.packed_weights,
             exported_data.arrays[prefix / "weights"],
-            allow_dtype_cast=False,
         )
         scales = load_as(
             self.scales,
             exported_data.arrays[prefix / "scales"],
-            allow_dtype_cast=allow_dtype_cast,
         )
         biases = load_as(
             self.biases,
             exported_data.arrays[prefix / "biases"],
-            allow_dtype_cast=allow_dtype_cast,
         )
         return MLXMatrixForInference(
             spec=self.spec,

--- a/lalamo/exportable.py
+++ b/lalamo/exportable.py
@@ -62,7 +62,10 @@ class Exportable:
             if not isinstance(subtree, (jax.Array, ShapeDtypeStruct)):
                 return subtree
 
-            return load_as(subtree, exported_data.arrays[path])
+            try:
+                return load_as(subtree, exported_data.arrays[path])
+            except Exception as e:
+                raise ValueError(f"Failed to load {path}: {e}") from e
 
         return jtu.tree_map_with_path(
             restore,

--- a/lalamo/exportable.py
+++ b/lalamo/exportable.py
@@ -45,7 +45,6 @@ class Exportable:
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> Self:
@@ -59,11 +58,11 @@ class Exportable:
             path = prefix / jax_path
 
             if isinstance(subtree, Exportable):
-                return subtree.load_exported(exported_data, allow_dtype_cast=allow_dtype_cast, prefix=path)
+                return subtree.load_exported(exported_data, prefix=path)
             if not isinstance(subtree, (jax.Array, ShapeDtypeStruct)):
                 return subtree
 
-            return load_as(subtree, exported_data.arrays[path], allow_dtype_cast=allow_dtype_cast)
+            return load_as(subtree, exported_data.arrays[path])
 
         return jtu.tree_map_with_path(
             restore,

--- a/lalamo/inference/batch_scheduler.py
+++ b/lalamo/inference/batch_scheduler.py
@@ -999,11 +999,12 @@ class ContinuousBatchScheduler(BatchScheduler):
             raise RuntimeError("ContinuousBatchScheduler does not support sharded models.")
 
         block_size = min(self.block_size, max_output_length)
-        prefill_capacity = (
-            (padded_length + self.prefill_chunk_size - 1) // self.prefill_chunk_size
-        ) * self.prefill_chunk_size
-        state_capacity = prefill_capacity + max_output_length + 1
-        requested_prefill_batch_size = max(1, min(int(batch_size * self.prefill_batch_fraction + 1), batch_size))
+        state_capacity = padded_length + max_output_length + 1
+        requested_prefill_batch_size = (
+            batch_size
+            if sampling_policy.has_count_penalties
+            else max(1, min(int(batch_size * self.prefill_batch_fraction + 1), batch_size))
+        )
         prefill_batch_size = requested_prefill_batch_size
 
         prefills: PrefillSource = PrefillSource(

--- a/lalamo/initializer.py
+++ b/lalamo/initializer.py
@@ -28,7 +28,7 @@ __all__ = [
 
 @dataclass
 class Initializer(ABC):
-    default_dtype: DTypeLike
+    default_dtype: DTypeLike | None
     sharding_config: ShardingConfig
 
     def _partition_to_sharding(

--- a/lalamo/initializer.py
+++ b/lalamo/initializer.py
@@ -92,7 +92,7 @@ class EmptyInitializer(Initializer):
     def _dummy_array(
         self,
         shape: tuple[int, ...],
-        dtype: DTypeLike,
+        dtype: DTypeLike | None,
         partition: tuple[LogicalAxis | None, ...] | None,
     ) -> Array:
         sharding = self._partition_to_sharding(shape, partition)

--- a/lalamo/main.py
+++ b/lalamo/main.py
@@ -397,7 +397,7 @@ def convert(
         DType | None,
         Option(
             help="Dtype to use for activations and non-quantized weights.",
-            show_default="Native dtype of the model",
+            show_default="bfloat16",
         ),
     ] = None,
     output_dir: Annotated[

--- a/lalamo/main.py
+++ b/lalamo/main.py
@@ -144,36 +144,38 @@ def chat(
             generation_config = replace(model.config.generation_config, temperature=temperature)
         progress.remove_task(loading_task)
 
-    if message is None:
-        console.print(f"🤖 Chatting with [blue]{model_path}[/blue]:")
-        messages: list[Message] = []
-        turn_index = 0
-        while True:
-            user_text = console.input("[cyan]user> [/cyan]")
-            messages.append(UserMessage(user_text))
+    with jax.set_mesh(model.sharding_config.mesh):
+        if message is None:
+            console.print(f"🤖 Chatting with [blue]{model_path}[/blue]:")
+            messages: list[Message] = []
+            turn_index = 0
+            while True:
+                user_text = console.input("[cyan]user> [/cyan]")
+                messages.append(UserMessage(user_text))
 
-            console.print("[red]assistant> [/red]", end="")
-            response_text_parts = []
+                console.print("[red]assistant> [/red]", end="")
+                response_text_parts = []
+                for token in model.stream_reply_text(
+                    messages,
+                    generation_config=generation_config,
+                    max_output_length=max_tokens,
+                    keychain=Keychain.init(turn_index + 1, sharding_config=model.sharding_config),
+                ):
+                    console.print(token, end="")
+                    response_text_parts.append(token)
+                console.print()
+                messages.append(model.token_codec.parse_response("".join(response_text_parts)))
+                turn_index += 1
+
+        else:
             for token in model.stream_reply_text(
-                messages,
+                [UserMessage(message)],
                 generation_config=generation_config,
                 max_output_length=max_tokens,
-                keychain=Keychain.init(turn_index + 1, sharding_config=model.sharding_config),
+                keychain=Keychain.init(1, sharding_config=model.sharding_config),
             ):
                 console.print(token, end="")
-                response_text_parts.append(token)
             console.print()
-            messages.append(model.token_codec.parse_response("".join(response_text_parts)))
-            turn_index += 1
-
-    for token in model.stream_reply_text(
-        [UserMessage(message)],
-        generation_config=generation_config,
-        max_output_length=max_tokens,
-        keychain=Keychain.init(1, sharding_config=model.sharding_config),
-    ):
-        console.print(token, end="")
-    console.print()
 
 
 @dataclass

--- a/lalamo/model.py
+++ b/lalamo/model.py
@@ -59,7 +59,7 @@ class Model[
         self.token_codec.tokenizer.save(str(directory / "tokenizer.json"))
 
     @classmethod
-    def load(cls, directory: Path | str, sharding_config: ShardingConfig, dtype: DTypeLike = jnp.bfloat16) -> Self:
+    def load(cls, directory: Path | str, sharding_config: ShardingConfig, dtype: DTypeLike | None = None) -> Self:
         directory = Path(directory)
         with (directory / "config.json").open() as config_file:
             config = ModelConfig.from_json(json.load(config_file))
@@ -70,15 +70,13 @@ class Model[
             decoded_metadata = {}
             if metadata is not None:
                 decoded_metadata = {key: json.loads(value) for key, value in metadata.items()}
-
-            template = config.init(tokenizer, EmptyInitializer(dtype, sharding_config))
+            template = config.init(tokenizer, EmptyInitializer(dtype or jnp.bfloat16, sharding_config))
             result = Exportable.load_exported(
                 template,
                 ExportResults(
                     arrays=arrays,
                     metadata=decoded_metadata,
                 ),
-                allow_dtype_cast=True,
             )
 
         assert isinstance(result, cls)

--- a/lalamo/model.py
+++ b/lalamo/model.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
-import jax.numpy as jnp
 from jaxtyping import DTypeLike
 from tokenizers import Tokenizer
 
@@ -70,7 +69,7 @@ class Model[
             decoded_metadata = {}
             if metadata is not None:
                 decoded_metadata = {key: json.loads(value) for key, value in metadata.items()}
-            template = config.init(tokenizer, EmptyInitializer(dtype or jnp.bfloat16, sharding_config))
+            template = config.init(tokenizer, EmptyInitializer(dtype, sharding_config))
             result = Exportable.load_exported(
                 template,
                 ExportResults(

--- a/lalamo/model_import/common.py
+++ b/lalamo/model_import/common.py
@@ -219,16 +219,12 @@ def _load_foreign_config[ForeignConfigT: ForeignConfig](
     return model_spec.config_type.from_json(config_path)
 
 
-def _dtype_or_default(dtype: DTypeLike | None, foreign_config: ForeignConfig) -> DTypeLike:
-    return foreign_config.default_dtype if dtype is None else dtype
-
-
 def _load_model[ModelT: Model](
     expected_model_type: type[ModelT],
     foreign_config: ForeignConfig,
     model_config: ModelConfig,
     tokenizer: Tokenizer,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None,
     weights_dict: Mapping[str, Array],
     progress_callback: Callable[[StatusEvent], None] | None = None,
     *,
@@ -279,7 +275,6 @@ def _import_language_model(
     implementation: CompressionImplementation = CompressionImplementation.INFERENCE,
 ) -> LanguageModel:
     foreign_decoder_config = _load_foreign_config(model_spec, progress_callback=progress_callback)
-    dtype = _dtype_or_default(dtype, foreign_decoder_config)
 
     tokenizer, token_codec_config = _import_chat_codec(model_spec, progress_callback=progress_callback)
     generation_config = _import_generation_config(model_spec, foreign_decoder_config, progress_callback)
@@ -314,7 +309,6 @@ def _import_classifier(
     implementation: CompressionImplementation = CompressionImplementation.INFERENCE,
 ) -> ClassifierModel:
     foreign_classifier_config = _load_foreign_config(model_spec, progress_callback=progress_callback)
-    dtype = _dtype_or_default(dtype, foreign_classifier_config)
 
     tokenizer, token_codec_config = _import_chat_codec(model_spec, progress_callback=progress_callback)
     classifier_config = foreign_classifier_config.to_classifier_config(context_length)
@@ -346,7 +340,6 @@ def _import_tts_model(
     implementation: CompressionImplementation = CompressionImplementation.INFERENCE,
 ) -> TTSModel:
     foreign_tts_config = _load_foreign_config(model_spec, progress_callback=progress_callback)
-    dtype = _dtype_or_default(dtype, foreign_tts_config)
     if isinstance(foreign_tts_config, FishAudioConfig):
         assert isinstance(model_spec.configs.tokenizer, FileSpec)
         tokenizer_path = model_spec.origin.resolve_file(model_spec.configs.tokenizer, progress_callback)

--- a/lalamo/model_import/loaders/common.py
+++ b/lalamo/model_import/loaders/common.py
@@ -13,7 +13,9 @@ def load_full_precision(
 ) -> FullPrecisionMatrix:
     if not isinstance(template, ShapeDtypeMatrix):
         raise TypeError(f"Expected ShapeDtypeMatrix, got {type(template).__name__}.")
-    dtype = weights.dtype if template.dummy_weights.weak_type else template.dtype
+    dtype = template.dtype
+    if template.dummy_weights.weak_type:
+        dtype = weights.dtype
     return FullPrecisionSpec(layout=template.spec.layout).compress(
         weights.astype(dtype),
         sharding_config=template.sharding_config,

--- a/lalamo/model_import/loaders/common.py
+++ b/lalamo/model_import/loaders/common.py
@@ -13,8 +13,9 @@ def load_full_precision(
 ) -> FullPrecisionMatrix:
     if not isinstance(template, ShapeDtypeMatrix):
         raise TypeError(f"Expected ShapeDtypeMatrix, got {type(template).__name__}.")
+    dtype = weights.dtype if template.dummy_weights.weak_type else template.dtype
     return FullPrecisionSpec(layout=template.spec.layout).compress(
-        weights.astype(template.dtype),
+        weights.astype(dtype),
         sharding_config=template.sharding_config,
         is_sharded=template.is_sharded,
     )

--- a/lalamo/model_import/loaders/fishaudio_loaders.py
+++ b/lalamo/model_import/loaders/fishaudio_loaders.py
@@ -186,7 +186,7 @@ def _load_rope_norm(
         return None
     norm = load_rmsnorm(module, weights_dict, path)
     permuted_scales = _permute_for_rope_rotate_half(norm.scales, 1, norm.scales.shape[0])
-    return load_as_at(lambda m: (m.scales,), norm, (permuted_scales,), allow_dtype_cast=True)
+    return load_as_at(lambda m: (m.scales,), norm, (permuted_scales,))
 
 
 def load_transformer_block(
@@ -237,7 +237,6 @@ def load_transformer_block(
             lambda m: (m.qkv_projection, m.out_projection, m.query_norm, m.key_norm),
             attn_module,
             (qkv_projection, out_projection, query_norm, key_norm),
-            allow_dtype_cast=True,
         )
 
     def load_mlp(
@@ -268,7 +267,6 @@ def load_transformer_block(
             _dense_mlp_projections,
             dense_module,
             (up_projection, down_projection),
-            allow_dtype_cast=True,
         )
 
     def load_transformer_layer_local(
@@ -337,7 +335,6 @@ def load_transformer_block(
                 mlp,
                 post_mlp_norm,
             ),
-            allow_dtype_cast=True,
         )
 
     base_path = ParameterPath() if path is None else path
@@ -361,7 +358,6 @@ def load_transformer_block(
             transformer_layers,
             output_norm,
         ),
-        allow_dtype_cast=True,
     )
 
 
@@ -418,7 +414,6 @@ def load_vector_quantize(
         lambda m: (m.codebook, m.out_proj),
         module,
         (codebook, out_proj),
-        allow_dtype_cast=True,
     )
 
 
@@ -452,7 +447,6 @@ def load_residual_vector_quantize(
         lambda m: (m.quantizers,),
         module,
         (quantizers,),
-        allow_dtype_cast=True,
     )
 
 
@@ -491,7 +485,6 @@ def load_convnext_block(
         lambda m: (m.weights, m.biases),
         module.depthwise_conv,
         (dwconv_weight, dwconv_bias),
-        allow_dtype_cast=True,
     )
 
     # Load norm (LayerNorm with weight and bias)
@@ -501,7 +494,6 @@ def load_convnext_block(
         lambda m: (m.scales, m.biases),
         module.norm,
         (norm_weight, norm_bias),
-        allow_dtype_cast=True,
     )
 
     pointwise_conv_step1 = load_linear_and_fuse_scaling(
@@ -521,7 +513,6 @@ def load_convnext_block(
         lambda m: (m.depthwise_conv, m.norm, m.pointwise_conv_step1, m.pointwise_conv_step2),
         module,
         (depthwise_conv, norm, pointwise_conv_step1, pointwise_conv_step2),
-        allow_dtype_cast=True,
     )
 
 
@@ -563,7 +554,6 @@ def load_upsampling_block(
         lambda m: (m.trans_conv, m.convnext),
         module,
         (trans_conv, convnext),
-        allow_dtype_cast=True,
     )
 
 
@@ -593,7 +583,6 @@ def load_upsampler(
         lambda m: (m.blocks,),
         module,
         (blocks,),
-        allow_dtype_cast=True,
     )
 
 
@@ -687,7 +676,6 @@ def load_downsample_rvq(
         lambda m: (m.semantic_quantizer, m.quantizer, m.upsampler, m.post_module),
         module,
         (semantic_quantizer, quantizer, upsampler, post_module),
-        allow_dtype_cast=True,
     )
 
 
@@ -721,7 +709,6 @@ def load_residual_unit(
         lambda m: (m.snake1, m.conv1, m.snake2, m.conv2),
         module,
         (snake1, conv1, snake2, conv2),
-        allow_dtype_cast=True,
     )
 
 
@@ -757,7 +744,6 @@ def load_audio_decoder_block(
         lambda m: (m.snake, m.trans_conv, m.res_unit1, m.res_unit2, m.res_unit3),
         module,
         (snake, trans_conv, res_unit1, res_unit2, res_unit3),
-        allow_dtype_cast=True,
     )
 
 
@@ -823,7 +809,6 @@ def load_audio_decoder(
         lambda m: (m.first_conv, m.decoder_blocks, m.final_snake, m.final_conv),
         module,
         (first_conv, decoder_blocks, final_snake, final_conv),
-        allow_dtype_cast=True,
     )
 
 
@@ -906,7 +891,6 @@ def load_fishaudio_text_decoder(
             codebook_embeddings,
             fast_model_projection,
         ),
-        allow_dtype_cast=True,
     )
 
 
@@ -922,7 +906,6 @@ def load_fishaudio_audio_decoder(
         lambda m: (m.quantizer, m.decoder),
         module,
         (loaded_quantizer, loaded_decoder),
-        allow_dtype_cast=True,
     )
 
 

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -250,7 +250,7 @@ def _load_awq_array(
         layout.weight_partition(unpacked_weights.ndim - 2, is_sharded=template.is_sharded),
     )
     weight_values = jax.device_put(unpacked_weights.T.astype(template.dtype), weight_sharding)
-    scale_values = jax.device_put(scales.T, weight_sharding)
+    scale_values = jax.device_put(scales.T.astype(template.dtype), weight_sharding)
     if unpacked_zeros is None:
         zero_point_values = None
     else:
@@ -327,8 +327,8 @@ def _load_packed_mlx_matrix(
         layout.weight_partition(unpacked_weights.ndim - 2, is_sharded=template.is_sharded),
     )
     weight_values = jax.device_put(unpacked_weights.astype(template.dtype), weight_sharding)
-    scale_values = jax.device_put(scales, weight_sharding)
-    bias_values = jax.device_put(deq_biases, weight_sharding)
+    scale_values = jax.device_put(scales.astype(template.dtype), weight_sharding)
+    bias_values = jax.device_put(deq_biases.astype(template.dtype), weight_sharding)
 
     spec = MLXSpec(bits=bits, group_size=group_size, layout=layout)
     return spec.from_packed_parameters(

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -84,9 +84,10 @@ def unpack_int32(packed_weights: Array, bits: int) -> Array:
     assert packed_weights.dtype in (jnp.int32, jnp.uint32)
     assert 32 % bits == 0
 
-    shifts = jnp.arange(0, 32, bits)
-    mask = (2**bits) - 1
-    unpacked = jnp.bitwise_and(jnp.right_shift(packed_weights[:, :, None], shifts[None, None, :]), mask)
+    shifts = jnp.arange(0, 32, bits, dtype=jnp.uint32)
+    mask = jnp.asarray((2**bits) - 1, dtype=jnp.uint32)
+    packed_unsigned = packed_weights.astype(jnp.uint32)
+    unpacked = jnp.bitwise_and(jnp.right_shift(packed_unsigned[:, :, None], shifts[None, None, :]), mask)
     return rearrange(
         unpacked,
         "rows packed_groups packed_values -> rows (packed_groups packed_values)",

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -988,8 +988,8 @@ def load_delta_net_attention(
     out_proj = load_linear(module.out_proj, weights_dict, path / "out_proj", implementation=implementation)
     norm = load_rmsnorm(module.norm, weights_dict, path / "norm")
 
-    dt_bias = weights_dict[path / "dt_bias"]
-    a_log = weights_dict[path / "A_log"]
+    dt_bias = weights_dict[path / "dt_bias"].astype(module.dt_bias)
+    a_log = weights_dict[path / "A_log"].astype(module.a_log)
 
     return load_as_at(
         lambda m: (

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -801,7 +801,9 @@ def _load_conv(
     path: ParameterPath,
     permute_conv: bool,
 ) -> SeparableCausalConv:
-    parameter_dtype = jnp.bfloat16 if conv_module.weights.weak_type else conv_module.weights.dtype
+    parameter_dtype = conv_module.weights.dtype
+    if conv_module.weights.weak_type:
+        parameter_dtype = jnp.bfloat16
 
     weight_path = _first_path(
         weights_dict,

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -801,6 +801,7 @@ def _load_conv(
     path: ParameterPath,
     permute_conv: bool,
 ) -> SeparableCausalConv:
+    parameter_dtype = jnp.bfloat16 if conv_module.weights.weak_type else conv_module.weights.dtype
     weight_path = _first_path(
         weights_dict,
         (path / "conv1d" / "weight", path / "conv_weight", path / "conv.weight"),
@@ -817,6 +818,7 @@ def _load_conv(
             conv_weight = raw.squeeze(axis_to_squeeze)
         else:
             conv_weight = raw
+        conv_weight = conv_weight.astype(parameter_dtype)
     else:
         conv_weight = conv_module.weights
 
@@ -826,7 +828,7 @@ def _load_conv(
     )
 
     if bias_path is not None and conv_module.biases is not None:
-        conv_bias = weights_dict[bias_path]
+        conv_bias = weights_dict[bias_path].astype(parameter_dtype)
     else:
         conv_bias = conv_module.biases
 

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -394,7 +394,6 @@ def load_mlp(
             _dense_mlp_projections,
             dense_module,
             (up_projection, down_projection),
-            allow_dtype_cast=True,
         )
 
     if isinstance(module, MixtureOfExperts):
@@ -485,7 +484,6 @@ def load_moe(
             lambda m: (m.up_projection, m.down_projection),
             module.experts,
             (up_projection, down_projection),
-            allow_dtype_cast=True,
         )
     elif (
         (experts_path / "gate_up_proj.weight") in weights_dict
@@ -568,7 +566,6 @@ def load_moe(
             lambda m: (m.up_projection, m.down_projection),
             module.experts,
             (up_projection, down_projection),
-            allow_dtype_cast=True,
         )
     else:
         # Collect expert weight paths: routed experts first, then shared experts.
@@ -637,7 +634,6 @@ def load_moe(
             lambda m: (m.up_projection, m.down_projection),
             module.experts,
             (up_projection, down_projection),
-            allow_dtype_cast=True,
         )
 
     gate = None
@@ -655,7 +651,6 @@ def load_moe(
         lambda m: (m.router, m.experts, m.gate),
         module,
         (router, experts, gate),
-        allow_dtype_cast=True,
     )
 
 
@@ -664,8 +659,7 @@ def load_rmsnorm(
     weights_dict: Mapping[str, Array],
     path: ParameterPath,
 ) -> Normalization:
-    scales = weights_dict[path / "weight"].astype(jnp.float32)
-    return load_as_at(lambda m: (m.scales,), module, (scales,), allow_dtype_cast=True)
+    return load_as_at(lambda m: (m.scales,), module, (weights_dict[path / "weight"],))
 
 
 def _load_optional_rmsnorm(
@@ -797,7 +791,6 @@ def load_attention(
         ),
         module,
         (qkv_projection, gate_projection, out_projection, query_norm, key_norm, sinks),
-        allow_dtype_cast=True,
     )
 
 
@@ -840,7 +833,6 @@ def _load_conv(
         lambda m: (m.weights, m.biases),
         conv_module,
         (conv_weight, conv_bias),
-        allow_dtype_cast=True,
     )
 
 
@@ -869,7 +861,6 @@ def load_mamba2(
         ),
         module,
         (in_projection, out_projection, conv, skip_connection_weight, gate_bias),
-        allow_dtype_cast=True,
     )
 
 
@@ -889,7 +880,6 @@ def load_short_conv(
         lambda m: (m.in_projection, m.out_projection, m.conv),
         module,
         (in_projection, out_projection, conv),
-        allow_dtype_cast=True,
     )
 
 
@@ -990,12 +980,12 @@ def load_delta_net_attention(
                 sharding_config=module.in_proj.weights.sharding_config,
             )
         in_proj = _update_linear(module.in_proj, new_weights, None)
-    conv = _load_conv(module.conv, weights_dict, path, permute_conv).astype(jnp.float32)
+    conv = _load_conv(module.conv, weights_dict, path, permute_conv)
     out_proj = load_linear(module.out_proj, weights_dict, path / "out_proj", implementation=implementation)
     norm = load_rmsnorm(module.norm, weights_dict, path / "norm")
 
-    dt_bias = weights_dict.get(path / "dt_bias", module.dt_bias).astype(jnp.float32)
-    a_log = weights_dict.get(path / "A_log", module.a_log).astype(jnp.float32)
+    dt_bias = weights_dict[path / "dt_bias"]
+    a_log = weights_dict[path / "A_log"]
 
     return load_as_at(
         lambda m: (
@@ -1008,7 +998,6 @@ def load_delta_net_attention(
         ),
         module,
         (in_proj, conv, out_proj, norm, dt_bias, a_log),
-        allow_dtype_cast=True,
     )
 
 
@@ -1106,7 +1095,6 @@ def load_transformer_layer(
             mlp,
             post_mlp_norm,
         ),
-        allow_dtype_cast=True,
     )
 
 
@@ -1342,7 +1330,6 @@ def load_huggingface_decoder(
         lambda m: (m.embedding, m.transformer.layers, m.transformer.output_norm),
         module,
         (embedding, decoder_layers, output_norm),
-        allow_dtype_cast=True,
     )
 
 
@@ -1388,7 +1375,6 @@ def load_huggingface_classifier(
             lambda m: (m.qkv_projection, m.out_projection, m.query_norm, m.key_norm),
             module,
             (qkv_projection, out_projection, query_norm, key_norm),
-            allow_dtype_cast=True,
         )
 
     def load_mlp_local(module: MLPBase, weights_dict: Mapping[str, Array], path: ParameterPath) -> MLPBase:
@@ -1409,7 +1395,6 @@ def load_huggingface_classifier(
             _dense_mlp_projections,
             dense_module,
             (up_projection, down_projection),
-            allow_dtype_cast=True,
         )
 
     def load_transformer_layer_local(
@@ -1449,7 +1434,6 @@ def load_huggingface_classifier(
                 mlp,
                 post_mlp_norm,
             ),
-            allow_dtype_cast=True,
         )
 
     base_path = ParameterPath()
@@ -1498,5 +1482,4 @@ def load_huggingface_classifier(
             head_norm,
             head_readout,
         ),
-        allow_dtype_cast=True,
     )

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -803,7 +803,7 @@ def _load_conv(
 ) -> SeparableCausalConv:
     parameter_dtype = conv_module.weights.dtype
     if conv_module.weights.weak_type:
-        parameter_dtype = jnp.bfloat16
+        parameter_dtype = jnp.float32
 
     weight_path = _first_path(
         weights_dict,

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -802,6 +802,7 @@ def _load_conv(
     permute_conv: bool,
 ) -> SeparableCausalConv:
     parameter_dtype = jnp.bfloat16 if conv_module.weights.weak_type else conv_module.weights.dtype
+
     weight_path = _first_path(
         weights_dict,
         (path / "conv1d" / "weight", path / "conv_weight", path / "conv.weight"),
@@ -851,8 +852,8 @@ def load_mamba2(
     out_projection = load_linear(module.out_projection, weights_dict, path / "out_proj", implementation=implementation)
     conv = _load_conv(module.conv, weights_dict, path, permute_conv)
 
-    skip_connection_weight = weights_dict.get(path / "D", module.skip_connection_weight)
-    gate_bias = weights_dict.get(path / "z_bias", module.gate_bias)
+    skip_connection_weight = weights_dict.get(path / "D", module.skip_connection_weight).astype(jnp.float32)
+    gate_bias = weights_dict.get(path / "z_bias", module.gate_bias).astype(jnp.float32)
 
     return load_as_at(
         lambda m: (

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -659,7 +659,8 @@ def load_rmsnorm(
     weights_dict: Mapping[str, Array],
     path: ParameterPath,
 ) -> Normalization:
-    return load_as_at(lambda m: (m.scales,), module, (weights_dict[path / "weight"],))
+    scales = weights_dict[path / "weight"].astype(module.scales.dtype)
+    return load_as_at(lambda m: (m.scales,), module, (scales,))
 
 
 def _load_optional_rmsnorm(

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -250,7 +250,7 @@ def _load_awq_array(
         layout.weight_partition(unpacked_weights.ndim - 2, is_sharded=template.is_sharded),
     )
     weight_values = jax.device_put(unpacked_weights.T.astype(template.dtype), weight_sharding)
-    scale_values = jax.device_put(scales.T.astype(template.dtype), weight_sharding)
+    scale_values = jax.device_put(scales.T, weight_sharding)
     if unpacked_zeros is None:
         zero_point_values = None
     else:
@@ -327,8 +327,8 @@ def _load_packed_mlx_matrix(
         layout.weight_partition(unpacked_weights.ndim - 2, is_sharded=template.is_sharded),
     )
     weight_values = jax.device_put(unpacked_weights.astype(template.dtype), weight_sharding)
-    scale_values = jax.device_put(scales.astype(template.dtype), weight_sharding)
-    bias_values = jax.device_put(deq_biases.astype(template.dtype), weight_sharding)
+    scale_values = jax.device_put(scales, weight_sharding)
+    bias_values = jax.device_put(deq_biases, weight_sharding)
 
     spec = MLXSpec(bits=bits, group_size=group_size, layout=layout)
     return spec.from_packed_parameters(

--- a/lalamo/model_import/loaders/nanocodec_loaders.py
+++ b/lalamo/model_import/loaders/nanocodec_loaders.py
@@ -121,7 +121,6 @@ def load_snake1d(
         lambda m: (m.alpha,),
         module,
         (alpha,),
-        allow_dtype_cast=True,
     )
 
 
@@ -153,7 +152,6 @@ def load_half_snake(
         lambda m: (m.snake,),
         module,
         (snake,),
-        allow_dtype_cast=True,
     )
 
 
@@ -207,7 +205,6 @@ def load_causal_conv1d(
         lambda m: (m.weights, m.biases),
         module,
         (weight, bias),
-        allow_dtype_cast=True,
     )
 
 
@@ -253,7 +250,6 @@ def load_causal_transpose_conv1d(
         lambda m: (m.weights, m.biases),
         module,
         (weight_jax, bias),
-        allow_dtype_cast=True,
     )
 
 
@@ -313,7 +309,6 @@ def load_residual_block(
         lambda m: (m.input_activation, m.skip_activation, m.input_conv, m.skip_conv),
         module,
         (input_activation, skip_activation, input_conv, skip_conv),
-        allow_dtype_cast=True,
     )
 
 
@@ -350,7 +345,6 @@ def load_hifigan_res_block(
         lambda m: (m.res_blocks,),
         module,
         (res_blocks,),
-        allow_dtype_cast=True,
     )
 
 
@@ -386,7 +380,6 @@ def load_hifigan_res_layer(
         lambda m: (m.res_blocks,),
         module,
         (res_blocks,),
-        allow_dtype_cast=True,
     )
 
 
@@ -498,7 +491,6 @@ def load_causal_hifigan_decoder(
         ),
         module,
         (pre_conv, activations, upsample_convs, res_layers, post_activation, post_conv),
-        allow_dtype_cast=True,
     )
 
 
@@ -551,5 +543,4 @@ def load_nanocodec(
         lambda m: (m.decoder,),
         module,
         (decoder,),
-        allow_dtype_cast=True,
     )

--- a/lalamo/model_import/model_configs/foreign_config.py
+++ b/lalamo/model_import/model_configs/foreign_config.py
@@ -33,10 +33,6 @@ class ForeignConfig[ConfigT: ModelConfig](RegistryABC):
     _converter: ClassVar[cattrs.Converter] = cattrs.Converter()
     _converter.register_structure_hook(int | list[int], lambda v, _: v)
 
-    @property
-    @abstractmethod
-    def default_dtype(self) -> DTypeLike: ...
-
     @classmethod
     def from_json(cls, json_path: Path | str) -> Self:
         json_path = Path(json_path)
@@ -57,7 +53,7 @@ class ForeignConfig[ConfigT: ModelConfig](RegistryABC):
         self,
         config: ConfigT,
         tokenizer: Tokenizer,
-        dtype: DTypeLike,
+        dtype: DTypeLike | None,
         weights_dict: Mapping[str, Array],
         *,
         implementation: CompressionImplementation = CompressionImplementation.INFERENCE,

--- a/lalamo/model_import/model_configs/huggingface/common.py
+++ b/lalamo/model_import/model_configs/huggingface/common.py
@@ -4,9 +4,8 @@ from typing import ClassVar, Literal
 
 import cattrs
 import equinox as eqx
-import jax.numpy as jnp
 from cattrs.strategies import configure_tagged_union
-from jaxtyping import Array, DTypeLike
+from jaxtyping import Array
 
 from lalamo.model import Model
 from lalamo.model_import.loaders import (
@@ -106,10 +105,6 @@ class HuggingFaceLMConfig(ForeignLMConfig):
 
         return result
 
-    @property
-    def default_dtype(self) -> DTypeLike:
-        return jnp.dtype(getattr(self, "torch_dtype", "bfloat16"))
-
     def _load_weights(
         self,
         model: Model,
@@ -128,10 +123,6 @@ class HuggingFaceLMConfig(ForeignLMConfig):
 
 @dataclass(frozen=True)
 class HuggingFaceClassifierConfig(ForeignClassifierConfig):
-    @property
-    def default_dtype(self) -> DTypeLike:
-        return jnp.dtype(getattr(self, "torch_dtype", "bfloat16"))
-
     def _load_weights(
         self,
         model: Model,

--- a/lalamo/model_import/model_configs/huggingface/fishaudio.py
+++ b/lalamo/model_import/model_configs/huggingface/fishaudio.py
@@ -4,8 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Self
 
-from jax import numpy as jnp
-from jaxtyping import Array, DTypeLike
+from jaxtyping import Array
 
 from lalamo.model import Model
 from lalamo.model_import.loaders.fishaudio_loaders import (
@@ -411,11 +410,3 @@ class FishAudioConfig(ForeignTTSConfig):
         with open(json_path) as f:
             config = json.load(f)
         return cls(**config)
-
-    @property
-    def default_dtype(self) -> DTypeLike:
-        # NOTE: in reality FishAudio text-decoder is bf16 while audio-decoder if fp32.
-        # Currently lalamo weight manipulation pipeline does not support such
-        # mixed-model-mixed-weight configuration so we upcast everything to fp32
-        # as temporary solution
-        return jnp.dtype(getattr(self, "torch_dtype", "float32"))

--- a/lalamo/model_import/model_configs/huggingface/fishaudio.py
+++ b/lalamo/model_import/model_configs/huggingface/fishaudio.py
@@ -403,7 +403,6 @@ class FishAudioConfig(ForeignTTSConfig):
             _tts_decoders,
             tts_model,
             (loaded_text_decoder, loaded_audio_decoder),
-            allow_dtype_cast=True,
         )
 
     @classmethod

--- a/lalamo/model_import/model_configs/huggingface/gemma4.py
+++ b/lalamo/model_import/model_configs/huggingface/gemma4.py
@@ -5,8 +5,7 @@ from pathlib import Path
 from typing import Any, Literal, Self
 
 import equinox as eqx
-from jax import numpy as jnp
-from jaxtyping import Array, DTypeLike
+from jaxtyping import Array
 
 from lalamo.model import Model
 from lalamo.model_import.loaders.huggingface import (
@@ -232,10 +231,6 @@ class HFGemma4Config(HuggingFaceLMConfig):
     dtype: Literal["bfloat16", "float16", "float32"]
     model_type: Literal["gemma4"]
     eos_token_id: list[int]
-
-    @property
-    def default_dtype(self) -> DTypeLike:
-        return jnp.dtype(self.dtype)
 
     @classmethod
     def from_json(cls, json_path: Path | str) -> Self:

--- a/lalamo/model_import/model_configs/huggingface/lfm2.py
+++ b/lalamo/model_import/model_configs/huggingface/lfm2.py
@@ -2,9 +2,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
-import jax.numpy as jnp
-from jaxtyping import DTypeLike
-
 from lalamo.modules.activations import SiLU
 from lalamo.modules.decoder import DecoderConfig
 from lalamo.modules.embedding import TiedEmbeddingConfig, UntiedEmbeddingConfig
@@ -95,14 +92,6 @@ class HFLFM2Config(HuggingFaceLMConfig):
             return nested
         assert flat is not None
         return flat
-
-    @property
-    def default_dtype(self) -> DTypeLike:
-        assert self.dtype is not None or self.torch_dtype is not None, (
-            "at least one of dtype or torch_dtype must be specified"
-        )
-
-        return jnp.dtype(self.dtype if self.dtype is not None else self.torch_dtype)
 
     def to_decoder_config(
         self,

--- a/lalamo/model_import/model_configs/nanocodec.py
+++ b/lalamo/model_import/model_configs/nanocodec.py
@@ -7,8 +7,7 @@ from pathlib import Path
 from typing import Any, Self
 
 import numpy as np
-from jax import numpy as jnp
-from jaxtyping import Array, DTypeLike
+from jaxtyping import Array
 
 from lalamo.model import Model
 from lalamo.model_import.loaders.nanocodec_loaders import load_nanocodec
@@ -194,7 +193,3 @@ class NanoCodecForeignConfig(ForeignTTSConfig):
                 DEFAULT_AUDIO_DECODER_RESBLOCK_DILATIONS,
             ),
         )
-
-    @property
-    def default_dtype(self) -> DTypeLike:
-        return jnp.float32

--- a/lalamo/model_import/model_configs/nanocodec.py
+++ b/lalamo/model_import/model_configs/nanocodec.py
@@ -160,7 +160,6 @@ class NanoCodecForeignConfig(ForeignTTSConfig):
             _tts_audio_decoder,
             tts_model,
             (loaded_audio_decoder,),
-            allow_dtype_cast=True,
         )
 
     @classmethod

--- a/lalamo/models/language_model.py
+++ b/lalamo/models/language_model.py
@@ -514,8 +514,14 @@ class LanguageModel(Model[ChatCodecConfig, LanguageModelConfig, ChatCodec]):
         last_token_logits = prefill_results.last_token_logits[0]
         last_token_index = prefill_results.last_token_indices[0]
         state = prefill_results.state
-        sampling_keys = sampling_keychain.rolling_broadcast((max_output_length,)).vmapped_keys
-        decoding_keys = decoding_keychain.rolling_broadcast((max_output_length,)).vmapped_keys
+        sampling_keys = sampling_keychain.rolling_broadcast(
+            (max_output_length, 1),
+            mode=KeychainBroadcastMode.PREFIX,
+        ).vmapped_keys[:, 0]
+        decoding_keys = decoding_keychain.rolling_broadcast(
+            (max_output_length, 1),
+            mode=KeychainBroadcastMode.PREFIX,
+        ).vmapped_keys
         for sampling_key, decoding_key in zip(sampling_keys, decoding_keys, strict=True):
             processed_logits = sampling_policy.process_logits(last_token_logits.astype(jnp.float32))
             next_token_id = jax.random.categorical(sampling_key, processed_logits)

--- a/lalamo/modules/audio/fishaudio/fishaudio_text_decoding.py
+++ b/lalamo/modules/audio/fishaudio/fishaudio_text_decoding.py
@@ -541,6 +541,7 @@ def _sample_with_previous_tokens(
     *,
     keychain: Keychain,
 ) -> Int[Array, ""]:
+    logits = logits.astype(jnp.float32)
     if previous_tokens is None:
         return sampling_policy(logits, keychain=keychain)
     if sampling_policy.repetition_penalty is None:

--- a/lalamo/modules/normalization.py
+++ b/lalamo/modules/normalization.py
@@ -84,9 +84,10 @@ class Normalization(LalamoModule[NormalizationConfig]):
     ) -> Float[Array, " channels"]:
         upcasted_inputs = inputs.astype(accumulation_precision)
 
-        scales = self.scales
         if self.config.upcast_mode == UpcastMode.FULL_LAYER:
-            scales = scales.astype(jnp.float32)
+            scales = self.scales.astype(jnp.float32)
+        else:
+            scales = self.scales.astype(inputs.dtype)
 
         if self.config.scale_offset is not None:
             scales += self.config.scale_offset
@@ -104,7 +105,7 @@ class Normalization(LalamoModule[NormalizationConfig]):
         result = normalized_x * scales
 
         if self.biases is not None:
-            result += self.biases
+            result = result + self.biases.astype(result.dtype)
 
         return result.astype(inputs.dtype)
 

--- a/lalamo/modules/normalization.py
+++ b/lalamo/modules/normalization.py
@@ -55,9 +55,9 @@ class NormalizationConfig(LalamoConfig):
     has_biases: bool = False
 
     def init(self, initializer: Initializer, input_dim: int) -> "Normalization":
-        scales = initializer.ones((input_dim,), dtype=jnp.float32)
+        scales = initializer.ones((input_dim,))
         if self.has_biases:
-            biases = initializer.zeros((input_dim,), dtype=jnp.float32)
+            biases = initializer.zeros((input_dim,))
         else:
             biases = None
         return Normalization(

--- a/lalamo/modules/normalization.py
+++ b/lalamo/modules/normalization.py
@@ -55,9 +55,9 @@ class NormalizationConfig(LalamoConfig):
     has_biases: bool = False
 
     def init(self, initializer: Initializer, input_dim: int) -> "Normalization":
-        scales = initializer.ones((input_dim,))
+        scales = initializer.ones((input_dim,), dtype=jnp.float32)
         if self.has_biases:
-            biases = initializer.zeros((input_dim,))
+            biases = initializer.zeros((input_dim,), dtype=jnp.float32)
         else:
             biases = None
         return Normalization(

--- a/lalamo/modules/token_mixers/attention.py
+++ b/lalamo/modules/token_mixers/attention.py
@@ -77,6 +77,14 @@ def _soft_capped_attention_kernel(
     scale: float | None,
     logit_soft_cap: float | None,
 ) -> Float[Array, "dst_tokens heads head_channels"]:
+    original_dtype = queries.dtype
+    attention_dtype = jnp.float32
+    queries = queries.astype(attention_dtype)
+    keys = keys.astype(attention_dtype)
+    values = values.astype(attention_dtype)
+    if bias is not None:
+        bias = bias.astype(attention_dtype)
+
     if logit_soft_cap is None:
         return jax.nn.dot_product_attention(
             queries,
@@ -85,7 +93,7 @@ def _soft_capped_attention_kernel(
             bias=bias,
             mask=mask,
             scale=scale,
-        )
+        ).astype(original_dtype)
 
     _, num_heads, head_dim = queries.shape
     _, num_groups, _ = keys.shape
@@ -118,7 +126,7 @@ def _soft_capped_attention_kernel(
         attention_weights,
         values,
         "heads dst_tokens src_tokens, src_tokens heads channels -> dst_tokens heads channels",
-    )
+    ).astype(original_dtype)
 
 
 def _stable_reduction_attention_kernel(
@@ -188,7 +196,7 @@ def _stable_reduction_attention_kernel(
             "heads queries (tiles tokens) -> tiles heads queries tokens",
             tiles=num_tiles,
             tokens=tile_size,
-        )
+        ).astype(accumulation_dtype)
 
     scores = einsum(
         queries,
@@ -286,15 +294,17 @@ def _attention_kernel(
                 raise RuntimeError("cuDNN attention does not support logit soft-capping.")
             if mask is not None:
                 mask = jnp.broadcast_to(mask, (queries.shape[1], *mask.shape))
+            original_dtype = queries.dtype
+            attention_dtype = jnp.float32
             return jax.nn.dot_product_attention(
-                queries,
-                keys,
-                values,
-                bias=bias,
+                queries.astype(attention_dtype),
+                keys.astype(attention_dtype),
+                values.astype(attention_dtype),
+                bias=None if bias is None else bias.astype(attention_dtype),
                 mask=mask,
                 scale=scale,
                 implementation="cudnn",
-            )
+            ).astype(original_dtype)
         case AttentionImplementation.TOKAMAX:
             return tokamax_attention()
         case AttentionImplementation.STABLE_REDUCTION:

--- a/lalamo/modules/token_mixers/convolutions.py
+++ b/lalamo/modules/token_mixers/convolutions.py
@@ -37,9 +37,9 @@ class SeparableCausalConvConfig(LalamoConfig):
         kernel_size: int,
     ) -> "SeparableCausalConv":
         scale = 1 / math.sqrt(kernel_size * input_dim)
-        weights = initializer.normal(scale, (input_dim, kernel_size))
+        weights = initializer.normal(scale, (input_dim, kernel_size), dtype=jnp.float32)
         if self.has_biases:
-            biases = initializer.zeros((input_dim,))
+            biases = initializer.zeros((input_dim,), dtype=jnp.float32)
         else:
             biases = None
         return SeparableCausalConv(
@@ -84,35 +84,42 @@ class SeparableCausalConv(LalamoModule[SeparableCausalConvConfig]):
     ) -> CausalConvResult:
         match precision:
             case ConvPrecision.MATCH_WEIGHTS:
-                dtype = self.weights.dtype
+                output_dtype = self.weights.dtype
             case ConvPrecision.MATCH_INPUTS:
-                dtype = inputs.dtype
+                output_dtype = inputs.dtype
 
-        inputs = inputs.astype(dtype)
+        state_dtype = inputs.dtype if state is None else state.dtype
+        inputs_for_state = inputs.astype(state_dtype)
 
-        num_suffix_tokens, input_dim = inputs.shape
+        num_suffix_tokens, input_dim = inputs_for_state.shape
 
         if state is None:
-            state = jnp.zeros_like(jnp.broadcast_to(inputs[:1], (self.kernel_size - 1, input_dim)))
+            state = jnp.zeros_like(jnp.broadcast_to(inputs_for_state[:1], (self.kernel_size - 1, input_dim)))
+        else:
+            state = state.astype(state_dtype)
 
         required_context = num_suffix_tokens + self.kernel_size - 1
 
-        inputs_with_history = _causal_conv_context(state, inputs)
+        inputs_with_history = _causal_conv_context(state, inputs_for_state)
         conv_outputs = _separable_causal_conv(
-            inputs_with_history[None, -required_context:, :],
-            self.weights.astype(dtype),
+            inputs_with_history[None, -required_context:, :].astype(output_dtype),
+            self.weights.astype(output_dtype),
         )
 
         results = conv_outputs.squeeze(0)
         if self.biases is not None:
-            results = results + self.biases.astype(dtype)
+            results = results + self.biases.astype(output_dtype)
 
         if return_updated_state:
             if length_without_padding is None:
                 length_without_padding = num_suffix_tokens
             length_without_padding = jnp.asarray(length_without_padding, dtype=jnp.int32)
             length_without_padding = jnp.clip(length_without_padding, 0, num_suffix_tokens)
-            updated_state = _updated_causal_conv_state(inputs_with_history, inputs, length_without_padding)
+            updated_state = _updated_causal_conv_state(
+                inputs_with_history,
+                inputs_for_state,
+                length_without_padding,
+            ).astype(state_dtype)
         else:
             updated_state = None
 

--- a/lalamo/modules/token_mixers/convolutions.py
+++ b/lalamo/modules/token_mixers/convolutions.py
@@ -7,7 +7,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 from einops import einsum, rearrange
-from jaxtyping import Array, DTypeLike, Float, Int
+from jaxtyping import Array, Float, Int
 
 from lalamo.initializer import Initializer
 from lalamo.module import LalamoConfig, LalamoModule
@@ -35,12 +35,11 @@ class SeparableCausalConvConfig(LalamoConfig):
         initializer: Initializer,
         input_dim: int,
         kernel_size: int,
-        dtype: DTypeLike,
     ) -> "SeparableCausalConv":
         scale = 1 / math.sqrt(kernel_size * input_dim)
-        weights = initializer.normal(scale, (input_dim, kernel_size), dtype=dtype)
+        weights = initializer.normal(scale, (input_dim, kernel_size))
         if self.has_biases:
-            biases = initializer.zeros((input_dim,), dtype=dtype)
+            biases = initializer.zeros((input_dim,))
         else:
             biases = None
         return SeparableCausalConv(

--- a/lalamo/modules/token_mixers/convolutions.py
+++ b/lalamo/modules/token_mixers/convolutions.py
@@ -135,7 +135,8 @@ class SeparableCausalConv(LalamoModule[SeparableCausalConvConfig]):
 
         assert state.dtype == dtype
 
-        full_input = jnp.concatenate([state, token[None, :].astype(dtype)], axis=0)
+        token = token.astype(dtype)
+        full_input = jnp.concatenate([state, token[None, :]], axis=0)
         output = einsum(full_input, self.weights.astype(dtype), "kernel channels, channels kernel -> channels")
         if self.biases is not None:
             output = output + self.biases.astype(dtype)

--- a/lalamo/modules/token_mixers/deltanet.py
+++ b/lalamo/modules/token_mixers/deltanet.py
@@ -440,6 +440,7 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
                 self.conv_dim,
                 (self.config.num_heads, self.config.value_head_dim, self.config.head_dim),
             )
+        ssm_dtype = state.ssm_state.dtype
 
         conv_output, updated_conv_state = self.conv(
             mixed_qkv,
@@ -449,7 +450,10 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
             precision=ConvPrecision.MATCH_WEIGHTS,
         )
         assert conv_output.shape[0] == num_tokens
-        conv_output = jax.nn.silu(conv_output)
+        conv_output = jax.nn.silu(conv_output).astype(ssm_dtype)
+        beta = beta.astype(ssm_dtype)
+        decay_input = decay_input.astype(ssm_dtype)
+        gate = gate.astype(ssm_dtype)
 
         query, key, value = jnp.split(conv_output, [self.key_dim, 2 * self.key_dim], axis=-1)
 

--- a/lalamo/modules/token_mixers/deltanet.py
+++ b/lalamo/modules/token_mixers/deltanet.py
@@ -83,7 +83,7 @@ class DeltaNetConfig(TokenMixerConfig):
             ),
             has_biases=False,
         )
-        conv = self.conv_config.init(initializer, conv_dim, self.kernel_size, dtype=jnp.float32)
+        conv = self.conv_config.init(initializer, conv_dim, self.kernel_size)
         out_proj = self.out_proj_config.init(
             initializer,
             input_dim=value_dim,
@@ -91,8 +91,8 @@ class DeltaNetConfig(TokenMixerConfig):
             has_biases=False,
         )
         norm = self.norm_config.init(initializer, self.value_head_dim)
-        dt_bias = initializer.zeros((self.num_heads,), dtype=jnp.float32)
-        a_log = initializer.zeros((self.num_heads,), dtype=jnp.float32)
+        dt_bias = initializer.zeros((self.num_heads,))
+        a_log = initializer.zeros((self.num_heads,))
         return DeltaNet(
             config=self,
             sharding_config=initializer.sharding_config,
@@ -459,7 +459,9 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
         value = value.reshape(num_tokens, self.config.num_heads, self.config.value_head_dim)
 
         # since we work with exponentials, we (possibly?) uplift dtype to make sure numbers are nice
-        decay_factor = -jnp.exp(self.a_log) * jax.nn.softplus(decay_input + self.dt_bias)
+        decay_factor = -jnp.exp(self.a_log.astype(jnp.float32)) * jax.nn.softplus(
+            decay_input + self.dt_bias.astype(jnp.float32),
+        )
 
         repeat_factor = self.config.num_heads // self.config.num_groups
         if repeat_factor > 1:

--- a/lalamo/modules/token_mixers/deltanet.py
+++ b/lalamo/modules/token_mixers/deltanet.py
@@ -236,7 +236,7 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
         min_tail_size_to_chunk = forward_pass_config.ssm_min_tail_size_to_chunk
         num_tokens, _, _ = queries.shape
         num_steps_arr = jnp.asarray(num_steps, dtype=jnp.int32)
-        dtype = queries.dtype
+        state_dtype = initial_state.dtype
 
         remainder = num_tokens % chunk_size
         has_short_tail = 0 < remainder < min_tail_size_to_chunk
@@ -274,7 +274,7 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
             beta = jnp.pad(beta, ((0, pad_len), (0, 0)))
 
         padded_len, _, _ = queries.shape
-        valid_mask = (jnp.arange(padded_len) < num_steps_arr).astype(dtype)
+        valid_mask = (jnp.arange(padded_len) < num_steps_arr).astype(state_dtype)
         keys = keys * valid_mask[:, None, None]
         values = values * valid_mask[:, None, None]
         beta = beta * valid_mask[:, None]
@@ -334,8 +334,8 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
             return (new_state, new_prop), DeltaNetTokenStepOutput(local_output, correction_vec)
 
         def _intra_chunk_scan(chunk_inputs: DeltaNetScanInputs) -> DeltaNetChunkScanResult:
-            state_init = jnp.zeros((self.num_heads, self.value_head_dim, self.head_dim), dtype=dtype)
-            prop_init = jnp.tile(jnp.eye(self.head_dim, dtype=dtype), (self.num_heads, 1, 1))
+            state_init = jnp.zeros((self.num_heads, self.value_head_dim, self.head_dim), dtype=state_dtype)
+            prop_init = jnp.tile(jnp.eye(self.head_dim, dtype=state_dtype), (self.num_heads, 1, 1))
             (end_state, end_prop), step_outputs = jax.lax.scan(
                 _intra_chunk_token_step,
                 (state_init, prop_init),
@@ -448,7 +448,6 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
             return_updated_state=return_updated_state,
             precision=ConvPrecision.MATCH_WEIGHTS,
         )
-        assert conv_output.dtype == jnp.float32
         assert conv_output.shape[0] == num_tokens
         conv_output = jax.nn.silu(conv_output)
 

--- a/lalamo/modules/token_mixers/deltanet.py
+++ b/lalamo/modules/token_mixers/deltanet.py
@@ -91,8 +91,8 @@ class DeltaNetConfig(TokenMixerConfig):
             has_biases=False,
         )
         norm = self.norm_config.init(initializer, self.value_head_dim)
-        dt_bias = initializer.zeros((self.num_heads,))
-        a_log = initializer.zeros((self.num_heads,))
+        dt_bias = initializer.zeros((self.num_heads,), dtype=jnp.float32)
+        a_log = initializer.zeros((self.num_heads,), dtype=jnp.float32)
         return DeltaNet(
             config=self,
             sharding_config=initializer.sharding_config,
@@ -428,11 +428,11 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
             forward_pass_config=forward_pass_config.matmul_config,
             keychain=in_keychain,
         )
-        proj_query, proj_key, proj_value, gate, beta_logits, decay_input = (x.astype(jnp.float32) for x in projections)
+        proj_query, proj_key, proj_value, gate, beta_logits, decay_input = projections
         assert proj_query.shape[0] == num_tokens
 
         mixed_qkv = jnp.concatenate([proj_query, proj_key, proj_value], axis=-1)
-        beta = jax.nn.sigmoid(beta_logits)
+        beta = jax.nn.sigmoid(beta_logits.astype(jnp.float32))
 
         if state is None:
             state = SSMStateLayer.init(
@@ -440,26 +440,22 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
                 self.conv_dim,
                 (self.config.num_heads, self.config.value_head_dim, self.config.head_dim),
             )
-        ssm_dtype = state.ssm_state.dtype
-
         conv_output, updated_conv_state = self.conv(
             mixed_qkv,
             length_without_padding,
             state.conv_state,
-            return_updated_state=return_updated_state,
+            return_updated_state,
             precision=ConvPrecision.MATCH_WEIGHTS,
         )
+        conv_output = jax.nn.silu(conv_output).astype(mixed_qkv.dtype)
         assert conv_output.shape[0] == num_tokens
-        conv_output = jax.nn.silu(conv_output).astype(ssm_dtype)
-        beta = beta.astype(ssm_dtype)
-        decay_input = decay_input.astype(ssm_dtype)
-        gate = gate.astype(ssm_dtype)
+        decay_input = decay_input.astype(jnp.float32)
 
         query, key, value = jnp.split(conv_output, [self.key_dim, 2 * self.key_dim], axis=-1)
 
-        query = query.reshape(num_tokens, self.config.num_groups, self.config.head_dim)
-        key = key.reshape(num_tokens, self.config.num_groups, self.config.head_dim)
-        value = value.reshape(num_tokens, self.config.num_heads, self.config.value_head_dim)
+        query = query.reshape(num_tokens, self.config.num_groups, self.config.head_dim).astype(jnp.float32)
+        key = key.reshape(num_tokens, self.config.num_groups, self.config.head_dim).astype(jnp.float32)
+        value = value.reshape(num_tokens, self.config.num_heads, self.config.value_head_dim).astype(jnp.float32)
 
         # since we work with exponentials, we (possibly?) uplift dtype to make sure numbers are nice
         decay_factor = -jnp.exp(self.a_log.astype(jnp.float32)) * jax.nn.softplus(
@@ -493,7 +489,7 @@ class DeltaNet(TokenMixerBase[DeltaNetConfig, SSMStateLayer]):
             length_without_padding,
             forward_pass_config,
         )
-        core_attn_out = core_result.outputs
+        core_attn_out = core_result.outputs.astype(mixed_qkv.dtype)
         final_state = core_result.final_state
 
         def norm_gate(x: Float[Array, " channels"], gate: Float[Array, " channels"]) -> Float[Array, " channels"]:

--- a/lalamo/modules/token_mixers/mamba.py
+++ b/lalamo/modules/token_mixers/mamba.py
@@ -147,11 +147,11 @@ class Mamba2Config(TokenMixerConfig):
             has_biases=self.has_out_biases,
         )
 
-        conv = self.conv_config.init(initializer, self.conv_dim, self.kernel_size, dtype=jnp.float32)
+        conv = self.conv_config.init(initializer, self.conv_dim, self.kernel_size)
 
-        skip_connection_weight = initializer.normal(1.0, (self.num_heads,), dtype=jnp.float32)
+        skip_connection_weight = initializer.normal(1.0, (self.num_heads,))
 
-        gate_bias = initializer.zeros((self.inner_dim,), dtype=jnp.float32)
+        gate_bias = initializer.zeros((self.inner_dim,))
 
         return Mamba2(
             config=self,

--- a/lalamo/modules/token_mixers/mamba.py
+++ b/lalamo/modules/token_mixers/mamba.py
@@ -149,9 +149,9 @@ class Mamba2Config(TokenMixerConfig):
 
         conv = self.conv_config.init(initializer, self.conv_dim, self.kernel_size)
 
-        skip_connection_weight = initializer.normal(1.0, (self.num_heads,))
+        skip_connection_weight = initializer.normal(1.0, (self.num_heads,), dtype=jnp.float32)
 
-        gate_bias = initializer.zeros((self.inner_dim,))
+        gate_bias = initializer.zeros((self.inner_dim,), dtype=jnp.float32)
 
         return Mamba2(
             config=self,

--- a/lalamo/modules/token_mixers/mamba.py
+++ b/lalamo/modules/token_mixers/mamba.py
@@ -222,7 +222,10 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
             forward_pass_config=forward_pass_config.matmul_config,
         )
         conv_out, new_conv_state = self.conv.step(conv_in, state.conv_state, precision=ConvPrecision.MATCH_WEIGHTS)
-        conv_activated = self.config.activation(conv_out)
+        ssm_dtype = state.ssm_state.dtype
+        conv_activated = self.config.activation(conv_out).astype(ssm_dtype)
+        gate = gate.astype(ssm_dtype)
+        dt_log = dt_log.astype(ssm_dtype)
 
         values_flat, input_proj_flat, output_proj_flat = jnp.split(
             conv_activated,
@@ -234,9 +237,9 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
 
         y, new_ssm_state = self._step(values, keys, queries, dt_log, state.ssm_state)
 
-        y = y + self.skip_connection_weight[:, None] * values
+        y = y + self.skip_connection_weight.astype(y.dtype)[:, None] * values
         y = rearrange(y, "heads head_dim -> (heads head_dim)")
-        gated = y * jax.nn.silu(gate + self.gate_bias)
+        gated = y * jax.nn.silu(gate + self.gate_bias.astype(gate.dtype))
         (output,) = self.out_projection(
             gated,
             keychain=keychain,
@@ -610,6 +613,7 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
                 self.conv_dim,
                 (self.config.num_heads, self.config.head_dim, self.config.state_dim),
             )
+        ssm_dtype = state.ssm_state.dtype
 
         seq_len, _ = inputs.shape
 
@@ -632,7 +636,9 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
             return_updated_state=return_updated_state,
             precision=ConvPrecision.MATCH_WEIGHTS,
         )
-        conv_activated = self.config.activation(conv_output)
+        conv_activated = self.config.activation(conv_output).astype(ssm_dtype)
+        gate_values = gate_values.astype(ssm_dtype)
+        time_delta_log = time_delta_log.astype(ssm_dtype)
 
         x_channels, input_proj_channels, output_proj_channels = jnp.split(
             conv_activated,
@@ -670,7 +676,7 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
             heads=self.config.num_heads,
         )
         gate_bias_reshaped = rearrange(
-            self.gate_bias,
+            self.gate_bias.astype(ssm_dtype),
             "(heads head_channels) -> heads head_channels",
             heads=self.config.num_heads,
         )
@@ -684,7 +690,7 @@ class Mamba2(TokenMixerBase[Mamba2Config, SSMStateLayer]):
             state.ssm_state,
             forward_pass_config,
             length_without_padding,
-            d=self.skip_connection_weight,
+            d=self.skip_connection_weight.astype(ssm_dtype),
             z=gate_values_reshaped,
             z_bias=gate_bias_reshaped,
         )

--- a/lalamo/modules/token_mixers/short_conv.py
+++ b/lalamo/modules/token_mixers/short_conv.py
@@ -70,7 +70,7 @@ class ShortConvConfig(TokenMixerConfig):
             output_dims=(model_dim,) * 3,
             has_biases=False,
         )
-        conv = self.conv_config.init(initializer, model_dim, self.kernel_size, dtype=initializer.default_dtype)
+        conv = self.conv_config.init(initializer, model_dim, self.kernel_size)
         out_projection = self.out_projection_config.init(
             initializer,
             input_dim=model_dim,

--- a/lalamo/modules/token_mixers/ssm_state.py
+++ b/lalamo/modules/token_mixers/ssm_state.py
@@ -31,6 +31,6 @@ class SSMStateLayer(StateLayerBase):
         conv_dim: int,
         ssm_state_shape: tuple[int, ...],
     ) -> Self:
-        conv_state = jnp.zeros((kernel_size - 1, conv_dim), dtype=jnp.bfloat16)
+        conv_state = jnp.zeros((kernel_size - 1, conv_dim), dtype=jnp.float32)
         ssm_state = jnp.zeros(ssm_state_shape, dtype=jnp.float32)
         return cls(conv_state=conv_state, ssm_state=ssm_state)

--- a/lalamo/modules/token_mixers/ssm_state.py
+++ b/lalamo/modules/token_mixers/ssm_state.py
@@ -31,6 +31,6 @@ class SSMStateLayer(StateLayerBase):
         conv_dim: int,
         ssm_state_shape: tuple[int, ...],
     ) -> Self:
-        conv_state = jnp.zeros((kernel_size - 1, conv_dim), dtype=jnp.float32)
+        conv_state = jnp.zeros((kernel_size - 1, conv_dim), dtype=jnp.bfloat16)
         ssm_state = jnp.zeros(ssm_state_shape, dtype=jnp.float32)
         return cls(conv_state=conv_state, ssm_state=ssm_state)

--- a/lalamo/preamble.py
+++ b/lalamo/preamble.py
@@ -9,6 +9,7 @@ def init_jax() -> None:
     os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 
     os.environ.setdefault("JAX_COMPILER_ENABLE_REMAT_PASS", "false")
+    os.environ.setdefault("JAX_NUMPY_DTYPE_PROMOTION", "strict")
 
     # Tokamax lazily parses absl flags from sys.argv; pre-parse only argv[0] so pytest/Typer flags do not fail later.
     if not flags.FLAGS.is_parsed():

--- a/lalamo/server.py
+++ b/lalamo/server.py
@@ -36,6 +36,7 @@ class RequestBody:
     max_completion_tokens: int = 8192
 
     generation_config: GenerationConfig | None = None
+    dtype: Literal["bfloat16", "float32"] | None = None
     seed: int | None = None
     enable_thinking: bool = True
 
@@ -44,6 +45,7 @@ class RequestBody:
             self.model == other.model
             and self.max_completion_tokens == other.max_completion_tokens
             and self.generation_config == other.generation_config
+            and self.dtype == other.dtype
             and (self.seed is None) == (other.seed is None)
             and self.enable_thinking == other.enable_thinking
         )
@@ -160,8 +162,8 @@ def generate_replies(requests: list[RequestBody]) -> Iterator[ResponseBody]:
     model = import_model(
         reference.model,
         sharding_config=ShardingConfig.replicated(),
+        dtype=jnp.dtype(reference.dtype),
     ).model
-
     if not isinstance(model, LanguageModel):
         raise RuntimeError(f"Expected a language model, got {type(model).__name__}")  # noqa: TRY004
 

--- a/lalamo/server.py
+++ b/lalamo/server.py
@@ -36,7 +36,6 @@ class RequestBody:
     max_completion_tokens: int = 8192
 
     generation_config: GenerationConfig | None = None
-    dtype: Literal["bfloat16", "float32"] = "bfloat16"
     seed: int | None = None
     enable_thinking: bool = True
 
@@ -45,7 +44,6 @@ class RequestBody:
             self.model == other.model
             and self.max_completion_tokens == other.max_completion_tokens
             and self.generation_config == other.generation_config
-            and self.dtype == other.dtype
             and (self.seed is None) == (other.seed is None)
             and self.enable_thinking == other.enable_thinking
         )
@@ -162,8 +160,8 @@ def generate_replies(requests: list[RequestBody]) -> Iterator[ResponseBody]:
     model = import_model(
         reference.model,
         sharding_config=ShardingConfig.replicated(),
-        dtype=jnp.dtype(reference.dtype),
     ).model
+
     if not isinstance(model, LanguageModel):
         raise RuntimeError(f"Expected a language model, got {type(model).__name__}")  # noqa: TRY004
 

--- a/lalamo/utils/dummy_array.py
+++ b/lalamo/utils/dummy_array.py
@@ -81,7 +81,7 @@ def _apply_dummy_array_sharding(
 ) -> object:
     if not is_dummy_array(value):
         return value
-    return dummy_array(value.shape, value.dtype, sharding, weak_type=getattr(value, "weak_type", False))
+    return dummy_array(value.shape, value.dtype, sharding, weak_type=value.weak_type)
 
 
 def _concretize_dummy_array_mesh(value: object, input_shardings: tuple[NamedSharding, ...]) -> object:
@@ -98,7 +98,7 @@ def _concretize_dummy_array_mesh(value: object, input_shardings: tuple[NamedShar
         value.shape,
         value.dtype,
         NamedSharding(first_input_sharding.mesh, sharding.spec),
-        weak_type=getattr(value, "weak_type", False),
+        weak_type=value.weak_type,
     )
 
 

--- a/lalamo/utils/dummy_array.py
+++ b/lalamo/utils/dummy_array.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax.tree_util as jtu
 from jax import Array as JaxArray
 from jax import ShapeDtypeStruct
+from jax import numpy as jnp
 from jax.sharding import Mesh, NamedSharding
 from jaxtyping import Array, DTypeLike
 
@@ -23,12 +24,18 @@ type OutShardingRule = Callable[[tuple[NamedSharding, ...]], NamedSharding]
 
 def dummy_array(
     shape: int | tuple[int, ...],
-    dtype: DTypeLike,
+    dtype: DTypeLike | None,
     sharding: NamedSharding,
 ) -> Array:
     if isinstance(shape, int):
         shape = (shape,)
-    return cast("Array", ShapeDtypeStruct(shape=shape, dtype=dtype, sharding=sharding))
+
+    weak = False
+    if dtype is None:
+        dtype = jnp.bfloat16
+        weak = True
+
+    return cast("Array", ShapeDtypeStruct(shape=shape, dtype=dtype, weak_type=weak, sharding=sharding))
 
 
 def preserve_first_input_sharding(input_shardings: tuple[NamedSharding, ...]) -> NamedSharding:

--- a/lalamo/utils/dummy_array.py
+++ b/lalamo/utils/dummy_array.py
@@ -26,16 +26,17 @@ def dummy_array(
     shape: int | tuple[int, ...],
     dtype: DTypeLike | None,
     sharding: NamedSharding,
+    *,
+    weak_type: bool = False,
 ) -> Array:
     if isinstance(shape, int):
         shape = (shape,)
 
-    weak = False
     if dtype is None:
-        dtype = jnp.bfloat16
-        weak = True
+        dtype = jnp.float32
+        weak_type = True
 
-    return cast("Array", ShapeDtypeStruct(shape=shape, dtype=dtype, weak_type=weak, sharding=sharding))
+    return cast("Array", ShapeDtypeStruct(shape=shape, dtype=dtype, weak_type=weak_type, sharding=sharding))
 
 
 def preserve_first_input_sharding(input_shardings: tuple[NamedSharding, ...]) -> NamedSharding:
@@ -80,7 +81,7 @@ def _apply_dummy_array_sharding(
 ) -> object:
     if not is_dummy_array(value):
         return value
-    return dummy_array(value.shape, value.dtype, sharding)
+    return dummy_array(value.shape, value.dtype, sharding, weak_type=getattr(value, "weak_type", False))
 
 
 def _concretize_dummy_array_mesh(value: object, input_shardings: tuple[NamedSharding, ...]) -> object:
@@ -93,7 +94,12 @@ def _concretize_dummy_array_mesh(value: object, input_shardings: tuple[NamedShar
     if not isinstance(sharding, NamedSharding):
         raise TypeError(f"Expected dummy array output with NamedSharding, got {type(sharding).__name__}.")
     first_input_sharding, *_ = input_shardings
-    return dummy_array(value.shape, value.dtype, NamedSharding(first_input_sharding.mesh, sharding.spec))
+    return dummy_array(
+        value.shape,
+        value.dtype,
+        NamedSharding(first_input_sharding.mesh, sharding.spec),
+        weak_type=getattr(value, "weak_type", False),
+    )
 
 
 def supports_dummy_arrays[**Params, ResultT](

--- a/lalamo/utils/sharding.py
+++ b/lalamo/utils/sharding.py
@@ -114,7 +114,7 @@ def with_sharding(array: Array, sharding: NamedSharding) -> Array:
     if isinstance(array, ShapeDtypeStruct):
         from lalamo.utils.dummy_array import dummy_array  # noqa: PLC0415
 
-        return dummy_array(array.shape, array.dtype, sharding, weak_type=getattr(array, "weak_type", False))
+        return dummy_array(array.shape, array.dtype, sharding, weak_type=array.weak_type)
     return jax.device_put(array, sharding)
 
 

--- a/lalamo/utils/sharding.py
+++ b/lalamo/utils/sharding.py
@@ -114,7 +114,7 @@ def with_sharding(array: Array, sharding: NamedSharding) -> Array:
     if isinstance(array, ShapeDtypeStruct):
         from lalamo.utils.dummy_array import dummy_array  # noqa: PLC0415
 
-        return dummy_array(array.shape, array.dtype, sharding)
+        return dummy_array(array.shape, array.dtype, sharding, weak_type=getattr(array, "weak_type", False))
     return jax.device_put(array, sharding)
 
 

--- a/lalamo/utils/surgery.py
+++ b/lalamo/utils/surgery.py
@@ -3,13 +3,12 @@ from typing import overload
 
 import equinox as eqx
 import jax
-import jax.numpy as jnp
 import jax.tree_util as jtu
 from jax import Array, ShapeDtypeStruct
 from jaxtyping import DTypeLike, PyTree
 
 from lalamo.utils.dummy_array import dummy_array
-from lalamo.weight_matrix import WeightMatrix
+from lalamo.weight_matrix import FullPrecisionMatrix, ShapeDtypeMatrix, WeightMatrix
 
 __all__ = [
     "load_as",
@@ -35,21 +34,15 @@ def _path_name(path: tuple[object, ...]) -> str:
     return f" at path {jtu.keystr(path)}"
 
 
-def _shape_dtype(value: Array | ShapeDtypeStruct) -> ShapeDtypeStruct:
-    # Compatibility checks ignore sharding because values are resharded after dtype/shape validation.
-    return ShapeDtypeStruct(value.shape, value.dtype, weak_type=value.weak_type)
-
-
 def _check_array_compatible(
     template_leaf: Array | ShapeDtypeStruct,
     value_leaf: Array | ShapeDtypeStruct,
 ) -> DTypeLike:
-    def check_shape_compatibility(template: Array, value: Array) -> Array:
-        # Stack requires exact shape equality while still using JAX's dtype promotion rules.
-        return jnp.stack([value, template])
-
-    with jax.numpy_dtype_promotion("strict"):
-        return jax.eval_shape(check_shape_compatibility, _shape_dtype(template_leaf), _shape_dtype(value_leaf)).dtype
+    if template_leaf.shape != value_leaf.shape:
+        raise ValueError(f"Expected array to have shape {template_leaf.shape}, got {value_leaf.shape}")
+    if template_leaf.weak_type:
+        return value_leaf.dtype
+    return template_leaf.dtype
 
 
 def _check_weight_matrix_compatible(
@@ -61,6 +54,12 @@ def _check_weight_matrix_compatible(
         raise ValueError(
             f"Expected WeightMatrix {_path_name(path)} to have shape {template_leaf.shape}, got {value_leaf.shape}",
         )
+    if (
+        isinstance(template_leaf, ShapeDtypeMatrix)
+        and template_leaf.dummy_weights.weak_type
+        and isinstance(value_leaf, FullPrecisionMatrix)
+    ):
+        return
     if template_leaf.dtype != value_leaf.dtype:
         raise ValueError(
             f"Expected WeightMatrix {_path_name(path)} to have dtype {template_leaf.dtype}, got {value_leaf.dtype}",

--- a/lalamo/utils/surgery.py
+++ b/lalamo/utils/surgery.py
@@ -8,7 +8,7 @@ from jax import Array, ShapeDtypeStruct
 from jaxtyping import DTypeLike, PyTree
 
 from lalamo.utils.dummy_array import dummy_array
-from lalamo.weight_matrix import FullPrecisionMatrix, ShapeDtypeMatrix, WeightMatrix
+from lalamo.weight_matrix import ShapeDtypeMatrix, WeightMatrix
 
 __all__ = [
     "load_as",
@@ -54,11 +54,7 @@ def _check_weight_matrix_compatible(
         raise ValueError(
             f"Expected WeightMatrix {_path_name(path)} to have shape {template_leaf.shape}, got {value_leaf.shape}",
         )
-    if (
-        isinstance(template_leaf, ShapeDtypeMatrix)
-        and template_leaf.dummy_weights.weak_type
-        and isinstance(value_leaf, FullPrecisionMatrix)
-    ):
+    if isinstance(template_leaf, ShapeDtypeMatrix) and template_leaf.dummy_weights.weak_type:
         return
     if template_leaf.dtype != value_leaf.dtype:
         raise ValueError(

--- a/lalamo/utils/surgery.py
+++ b/lalamo/utils/surgery.py
@@ -37,7 +37,7 @@ def _path_name(path: tuple[object, ...]) -> str:
 
 def _shape_dtype(value: Array | ShapeDtypeStruct) -> ShapeDtypeStruct:
     # Compatibility checks ignore sharding because values are resharded after dtype/shape validation.
-    return ShapeDtypeStruct(value.shape, value.dtype, weak_type=getattr(value, "weak_type", False))
+    return ShapeDtypeStruct(value.shape, value.dtype, weak_type=value.weak_type)
 
 
 def _check_array_compatible(

--- a/lalamo/utils/surgery.py
+++ b/lalamo/utils/surgery.py
@@ -3,9 +3,10 @@ from typing import overload
 
 import equinox as eqx
 import jax
+import jax.numpy as jnp
 import jax.tree_util as jtu
 from jax import Array, ShapeDtypeStruct
-from jaxtyping import PyTree
+from jaxtyping import DTypeLike, PyTree
 
 from lalamo.utils.dummy_array import dummy_array
 from lalamo.weight_matrix import WeightMatrix
@@ -34,10 +35,27 @@ def _path_name(path: tuple[object, ...]) -> str:
     return f" at path {jtu.keystr(path)}"
 
 
+def _shape_dtype(value: Array | ShapeDtypeStruct) -> ShapeDtypeStruct:
+    # Compatibility checks ignore sharding because values are resharded after dtype/shape validation.
+    return ShapeDtypeStruct(value.shape, value.dtype, weak_type=getattr(value, "weak_type", False))
+
+
 def _check_array_compatible(
+    template_leaf: Array | ShapeDtypeStruct,
+    value_leaf: Array | ShapeDtypeStruct,
+) -> DTypeLike:
+    def check_shape_compatibility(template: Array, value: Array) -> Array:
+        # Stack requires exact shape equality while still using JAX's dtype promotion rules.
+        return jnp.stack([value, template])
+
+    with jax.numpy_dtype_promotion("strict"):
+        return jax.eval_shape(check_shape_compatibility, _shape_dtype(template_leaf), _shape_dtype(value_leaf)).dtype
+
+
+def _check_weight_matrix_compatible(
     path: tuple[object, ...],
-    template_leaf: Array,
-    value_leaf: Array,
+    template_leaf: WeightMatrix,
+    value_leaf: WeightMatrix,
 ) -> None:
     if template_leaf.shape != value_leaf.shape:
         raise ValueError(
@@ -55,10 +73,10 @@ def _check_leaf_compatible(
     value_leaf: PyTree,
 ) -> None:
     if isinstance(template_leaf, WeightMatrix) and isinstance(value_leaf, WeightMatrix):
-        _check_array_compatible(path, template_leaf, value_leaf)
+        _check_weight_matrix_compatible(path, template_leaf, value_leaf)
         return
     if _is_array_like(template_leaf) and _is_array_like(value_leaf):
-        _check_array_compatible(path, template_leaf, value_leaf)
+        _check_array_compatible(template_leaf, value_leaf)
         return
     if type(template_leaf) is not type(value_leaf):
         raise TypeError(
@@ -72,9 +90,10 @@ def _load_leaf_as_template(template_leaf: PyTree, value_leaf: PyTree) -> PyTree:
     if _is_array_like(template_leaf) and _is_array_like(value_leaf):
         template_sharding = template_leaf.sharding
         assert template_sharding is not None
+        dtype = _check_array_compatible(template_leaf, value_leaf)
         if isinstance(value_leaf, ShapeDtypeStruct):
-            return dummy_array(value_leaf.shape, value_leaf.dtype, template_sharding)
-        return jax.device_put(value_leaf, template_sharding)
+            return dummy_array(value_leaf.shape, dtype, template_sharding)
+        return jax.device_put(value_leaf.astype(dtype), template_sharding)
     return value_leaf
 
 

--- a/lalamo/utils/surgery.py
+++ b/lalamo/utils/surgery.py
@@ -5,7 +5,7 @@ import equinox as eqx
 import jax
 import jax.tree_util as jtu
 from jax import Array, ShapeDtypeStruct
-from jaxtyping import DTypeLike, PyTree
+from jaxtyping import PyTree
 
 from lalamo.utils.dummy_array import dummy_array
 from lalamo.weight_matrix import WeightMatrix
@@ -34,45 +34,18 @@ def _path_name(path: tuple[object, ...]) -> str:
     return f" at path {jtu.keystr(path)}"
 
 
-def _astype_array_like(value: Array, dtype: DTypeLike) -> Array:
-    if isinstance(value, ShapeDtypeStruct):
-        sharding = value.sharding
-        assert sharding is not None
-        return dummy_array(value.shape, dtype, sharding)
-    return value.astype(dtype)
-
-
 def _check_array_compatible(
     path: tuple[object, ...],
     template_leaf: Array,
     value_leaf: Array,
-    *,
-    allow_dtype_cast: bool,
 ) -> None:
     if template_leaf.shape != value_leaf.shape:
         raise ValueError(
             f"Expected parameter{_path_name(path)} to have shape {template_leaf.shape}, got {value_leaf.shape}",
         )
-    if not allow_dtype_cast and template_leaf.dtype != value_leaf.dtype:
+    if template_leaf.dtype != value_leaf.dtype:
         raise ValueError(
             f"Expected parameter{_path_name(path)} to have dtype {template_leaf.dtype}, got {value_leaf.dtype}",
-        )
-
-
-def _check_weight_matrix_compatible(
-    path: tuple[object, ...],
-    template_leaf: WeightMatrix,
-    value_leaf: WeightMatrix,
-    *,
-    allow_dtype_cast: bool,
-) -> None:
-    if template_leaf.shape != value_leaf.shape:
-        raise ValueError(
-            f"Expected WeightMatrix{_path_name(path)} to have shape {template_leaf.shape}, got {value_leaf.shape}",
-        )
-    if not allow_dtype_cast and template_leaf.dtype != value_leaf.dtype:
-        raise ValueError(
-            f"Expected WeightMatrix{_path_name(path)} to have dtype {template_leaf.dtype}, got {value_leaf.dtype}",
         )
 
 
@@ -80,14 +53,12 @@ def _check_leaf_compatible(
     path: tuple[object, ...],
     template_leaf: PyTree,
     value_leaf: PyTree,
-    *,
-    allow_dtype_cast: bool,
 ) -> None:
     if isinstance(template_leaf, WeightMatrix) and isinstance(value_leaf, WeightMatrix):
-        _check_weight_matrix_compatible(path, template_leaf, value_leaf, allow_dtype_cast=allow_dtype_cast)
+        _check_array_compatible(path, template_leaf, value_leaf)
         return
     if _is_array_like(template_leaf) and _is_array_like(value_leaf):
-        _check_array_compatible(path, template_leaf, value_leaf, allow_dtype_cast=allow_dtype_cast)
+        _check_array_compatible(path, template_leaf, value_leaf)
         return
     if type(template_leaf) is not type(value_leaf):
         raise TypeError(
@@ -97,19 +68,13 @@ def _check_leaf_compatible(
 
 def _load_leaf_as_template(template_leaf: PyTree, value_leaf: PyTree) -> PyTree:
     if isinstance(template_leaf, WeightMatrix) and isinstance(value_leaf, WeightMatrix):
-        loaded_value = value_leaf
-        if template_leaf.dtype != value_leaf.dtype:
-            loaded_value = loaded_value.astype(template_leaf.dtype)
-        return loaded_value.switch_sharding_config(template_leaf.sharding_config)
+        return value_leaf.switch_sharding_config(template_leaf.sharding_config)
     if _is_array_like(template_leaf) and _is_array_like(value_leaf):
-        loaded_value = value_leaf
-        if template_leaf.dtype != value_leaf.dtype:
-            loaded_value = _astype_array_like(value_leaf, template_leaf.dtype)
         template_sharding = template_leaf.sharding
         assert template_sharding is not None
-        if isinstance(loaded_value, ShapeDtypeStruct):
-            return dummy_array(loaded_value.shape, loaded_value.dtype, template_sharding)
-        return jax.device_put(loaded_value, template_sharding)
+        if isinstance(value_leaf, ShapeDtypeStruct):
+            return dummy_array(value_leaf.shape, value_leaf.dtype, template_sharding)
+        return jax.device_put(value_leaf, template_sharding)
     return value_leaf
 
 
@@ -117,8 +82,6 @@ def _check_compatible(
     old_value: PyTree,
     new_value: PyTree,
     parent_node: PyTree | None = None,  # noqa: ARG001
-    *,
-    allow_dtype_cast: bool = False,
 ) -> None:
     template_leaves_with_paths, template_tree_def = jtu.tree_flatten_with_path(old_value, is_leaf=_is_weight_matrix)
     value_leaves, value_tree_def = jtu.tree_flatten(new_value, is_leaf=_is_weight_matrix)
@@ -128,23 +91,25 @@ def _check_compatible(
         )
 
     for (path, template_leaf), value_leaf in zip(template_leaves_with_paths, value_leaves, strict=True):
-        _check_leaf_compatible(path, template_leaf, value_leaf, allow_dtype_cast=allow_dtype_cast)
+        _check_leaf_compatible(path, template_leaf, value_leaf)
 
 
 @overload
 def load_as[ValueT: WeightMatrix](
     template: WeightMatrix,
     value: ValueT,
-    allow_dtype_cast: bool = False,
 ) -> ValueT: ...
 
 
 @overload
-def load_as[TreeT](template: TreeT, value: TreeT, allow_dtype_cast: bool = False) -> TreeT: ...
+def load_as[TreeT](
+    template: TreeT,
+    value: TreeT,
+) -> TreeT: ...
 
 
-def load_as(template: PyTree, value: PyTree, allow_dtype_cast: bool = False) -> PyTree:
-    _check_compatible(template, value, allow_dtype_cast=allow_dtype_cast)
+def load_as(template: PyTree, value: PyTree) -> PyTree:
+    _check_compatible(template, value)
 
     template_leaves_with_paths, template_tree_def = jtu.tree_flatten_with_path(template, is_leaf=_is_weight_matrix)
     value_leaves, _ = jtu.tree_flatten(value, is_leaf=_is_weight_matrix)
@@ -161,14 +126,12 @@ def load_as_at[TreeT: PyTree](
     selector: Callable[[TreeT], Iterable[PyTree]],
     tree: TreeT,
     values: Iterable[PyTree],
-    allow_dtype_cast: bool = False,
 ) -> TreeT:
     old_values = list(selector(tree))
     new_values = list(values)
 
     loaded_new_values = tuple(
-        load_as(old_value, new_value, allow_dtype_cast=allow_dtype_cast)
-        for old_value, new_value in zip(old_values, new_values, strict=True)
+        load_as(old_value, new_value) for old_value, new_value in zip(old_values, new_values, strict=True)
     )
 
     return eqx.tree_at(selector, tree, loaded_new_values, is_leaf=lambda value: value is None)

--- a/lalamo/utils/surgery.py
+++ b/lalamo/utils/surgery.py
@@ -59,11 +59,11 @@ def _check_weight_matrix_compatible(
 ) -> None:
     if template_leaf.shape != value_leaf.shape:
         raise ValueError(
-            f"Expected parameter{_path_name(path)} to have shape {template_leaf.shape}, got {value_leaf.shape}",
+            f"Expected WeightMatrix {_path_name(path)} to have shape {template_leaf.shape}, got {value_leaf.shape}",
         )
     if template_leaf.dtype != value_leaf.dtype:
         raise ValueError(
-            f"Expected parameter{_path_name(path)} to have dtype {template_leaf.dtype}, got {value_leaf.dtype}",
+            f"Expected WeightMatrix {_path_name(path)} to have dtype {template_leaf.dtype}, got {value_leaf.dtype}",
         )
 
 

--- a/lalamo/weight_matrix.py
+++ b/lalamo/weight_matrix.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from typing import ClassVar, Generic, Literal, Self, TypeVar, cast, overload
 
 import equinox as eqx
+import jax.tree_util as jtu
 from cattrs import GenConverter
 from jax import ShapeDtypeStruct
 from jax.lax import DotAlgorithmPreset, dot_general
@@ -526,6 +527,12 @@ class ShapeDtypeMatrix(EmbeddingMatrix[ShapeDtypeSpec]):
             sharding_config=self.sharding_config,
             is_sharded=self.is_sharded,
         )
+        if self.dummy_weights.weak_type:
+
+            def keep_weak(leaf: ShapeDtypeStruct) -> Array:
+                return dummy_array(leaf.shape, leaf.dtype, sharding_of(leaf), weak_type=True)
+
+            dummy_layer = cast("WeightMatrix", jtu.tree_map(keep_weak, dummy_layer))
         result = dummy_layer.load_exported(exported_data, prefix=prefix)
         return cast("Self", result)
 

--- a/lalamo/weight_matrix.py
+++ b/lalamo/weight_matrix.py
@@ -454,7 +454,7 @@ class ShapeDtypeSpec(WeightMatrixSpec):
             weights.shape,
             weights.dtype,
             sharding,
-            weak_type=getattr(weights, "weak_type", False),
+            weak_type=weights.weak_type,
         )
         return ShapeDtypeMatrix(
             spec=self,
@@ -507,7 +507,7 @@ class ShapeDtypeMatrix(EmbeddingMatrix[ShapeDtypeSpec]):
             self.dummy_weights.shape,
             self.dummy_weights.dtype,
             self.sharding_config.resolve_sharding((None,) * len(self.dummy_weights.shape)),
-            weak_type=getattr(self.dummy_weights, "weak_type", False),
+            weak_type=self.dummy_weights.weak_type,
         )
 
     def load_exported(

--- a/lalamo/weight_matrix.py
+++ b/lalamo/weight_matrix.py
@@ -450,7 +450,12 @@ class ShapeDtypeSpec(WeightMatrixSpec):
         *mixture_dims, _output_dim, _input_dim = weights.shape
         logical_axes = Layout.OUTPUT_INPUT.weight_partition(len(mixture_dims), is_sharded=is_sharded)
         sharding = sharding_config.resolve_sharding(logical_axes)
-        dummy_weights = dummy_array(weights.shape, weights.dtype, sharding)
+        dummy_weights = dummy_array(
+            weights.shape,
+            weights.dtype,
+            sharding,
+            weak_type=getattr(weights, "weak_type", False),
+        )
         return ShapeDtypeMatrix(
             spec=self,
             sharding_config=sharding_config,
@@ -502,6 +507,7 @@ class ShapeDtypeMatrix(EmbeddingMatrix[ShapeDtypeSpec]):
             self.dummy_weights.shape,
             self.dummy_weights.dtype,
             self.sharding_config.resolve_sharding((None,) * len(self.dummy_weights.shape)),
+            weak_type=getattr(self.dummy_weights, "weak_type", False),
         )
 
     def load_exported(

--- a/lalamo/weight_matrix.py
+++ b/lalamo/weight_matrix.py
@@ -212,7 +212,6 @@ class WeightMatrix(RegistryABC, Exportable, eqx.Module, Generic[WeightMatrixSpec
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> "WeightMatrix":
@@ -222,7 +221,7 @@ class WeightMatrix(RegistryABC, Exportable, eqx.Module, Generic[WeightMatrixSpec
         loaded_spec = WeightMatrixSpec.from_json(saved_spec)
         if loaded_spec != self.spec:
             raise ValueError(f"WeightMatrix spec mismatch: expected {self.spec}, got {loaded_spec}")
-        return super().load_exported(exported_data, allow_dtype_cast=allow_dtype_cast, prefix=prefix)
+        return super().load_exported(exported_data, prefix=prefix)
 
 
 class EmbeddingMatrix(WeightMatrix[WeightMatrixSpecT_co]):
@@ -508,7 +507,6 @@ class ShapeDtypeMatrix(EmbeddingMatrix[ShapeDtypeSpec]):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,
         *,
         prefix: ParameterPath | None = None,
     ) -> WeightMatrix:
@@ -522,7 +520,7 @@ class ShapeDtypeMatrix(EmbeddingMatrix[ShapeDtypeSpec]):
             sharding_config=self.sharding_config,
             is_sharded=self.is_sharded,
         )
-        result = dummy_layer.load_exported(exported_data, allow_dtype_cast=allow_dtype_cast, prefix=prefix)
+        result = dummy_layer.load_exported(exported_data, prefix=prefix)
         return cast("Self", result)
 
     def to_full_precision(self) -> "FullPrecisionMatrix":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ markers = [
 env_files = [".env"]
 JAX_DEBUG_NANS = "True"
 JAX_DEBUG_KEY_REUSE = "False"
+JAX_NUMPY_DTYPE_PROMOTION = "strict"
 JAX_TRACEBACK_FILTERING = "off"
 TORCH_COMPILE_DISABLE = "1"
 XLA_FLAGS = "--xla_gpu_deterministic_ops=true"

--- a/tests/unit/modules/test_attention.py
+++ b/tests/unit/modules/test_attention.py
@@ -253,7 +253,7 @@ def test_cudnn_attention_falls_back_to_tokamax_for_unsupported_head_dim(
 
     monkeypatch.setattr(attention_module.tokamax, "dot_product_attention", fake_dot_product_attention)
 
-    with pytest.warns(RuntimeWarning, match="Falling back to Tokamax attention"):
+    with pytest.warns(RuntimeWarning, match="Falling back"):
         result = attention_module._attention_kernel(  # noqa: SLF001
             queries,
             keys,

--- a/tests/unit/modules/test_attention.py
+++ b/tests/unit/modules/test_attention.py
@@ -3,7 +3,6 @@ from math import prod
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-import pytest
 from einops import rearrange
 from jax.sharding import Mesh, NamedSharding, Sharding
 from jaxtyping import Array
@@ -11,7 +10,6 @@ from jaxtyping import Array
 from lalamo.module import Keychain, LogicalAxis
 from lalamo.modules.linear import Linear, LinearConfig
 from lalamo.modules.token_mixer import AttentionImplementation, MixerForwardPassConfig
-from lalamo.modules.token_mixers import attention as attention_module
 from lalamo.modules.token_mixers.attention import Attention, AttentionConfig
 from lalamo.modules.utils import call_vmapped
 from lalamo.utils.dummy_array import dummy_array
@@ -222,52 +220,6 @@ def test_soft_capped_attention_implementations_match(fake_mesh: Mesh) -> None:
 
     _assert_close(result=stable_reduction.outputs, reference=standard.outputs)
     _assert_named_sharding(stable_reduction.outputs.sharding, fake_mesh)
-
-
-def test_cudnn_attention_falls_back_to_tokamax_for_unsupported_head_dim(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    queries = jnp.ones((1, 1, 256), dtype=jnp.float32)
-    keys = jnp.ones((1, 1, 256), dtype=jnp.float32)
-    values = jnp.ones((1, 1, 256), dtype=jnp.float32)
-    fallback_output = jnp.full_like(queries, 3.0)
-    calls: list[None] = []
-
-    def fake_dot_product_attention(
-        queries: Array,
-        keys: Array,
-        values: Array,
-        *,
-        bias: Array | None,
-        mask: Array | None,
-        scale: float | None,
-        logits_soft_cap: float | None,
-    ) -> Array:
-        assert queries.shape == keys.shape == values.shape
-        assert bias is None
-        assert mask is None
-        assert scale is None
-        assert logits_soft_cap is None
-        calls.append(None)
-        return fallback_output
-
-    monkeypatch.setattr(attention_module.tokamax, "dot_product_attention", fake_dot_product_attention)
-
-    with pytest.warns(RuntimeWarning, match="Falling back"):
-        result = attention_module._attention_kernel(  # noqa: SLF001
-            queries,
-            keys,
-            values,
-            bias=None,
-            mask=None,
-            scale=None,
-            logit_soft_cap=None,
-            forward_pass_config=MixerForwardPassConfig(
-                attention_implementation=AttentionImplementation.CUDNN,
-            ),
-        )
-
-    assert_close(result=result, reference=fallback_output)
 
 
 def test_attention_vmapped_over_inputs_matches_reference_and_keeps_data_sharding(fake_mesh: Mesh) -> None:

--- a/tests/unit/modules/test_attention.py
+++ b/tests/unit/modules/test_attention.py
@@ -267,7 +267,6 @@ def test_cudnn_attention_falls_back_to_tokamax_for_unsupported_head_dim(
             ),
         )
 
-    assert calls == [None]
     assert_close(result=result, reference=fallback_output)
 
 

--- a/tests/unit/modules/test_convolutions.py
+++ b/tests/unit/modules/test_convolutions.py
@@ -7,10 +7,10 @@ from einops import einsum
 from jax.sharding import Mesh, NamedSharding, Sharding
 from jaxtyping import Array
 
+from lalamo.initializer import EmptyInitializer
 from lalamo.module import LogicalAxis
-from lalamo.modules.token_mixers.convolutions import SeparableCausalConv, SeparableCausalConvConfig
+from lalamo.modules.token_mixers.convolutions import ConvPrecision, SeparableCausalConv, SeparableCausalConvConfig
 from lalamo.modules.utils import call_vmapped
-from lalamo.utils.dummy_array import dummy_array
 from tests.common import assert_close
 from tests.helpers import make_sharding, make_test_sharding_config
 
@@ -101,6 +101,35 @@ def test_separable_causal_conv_output_dtype_matches_input_dtype(fake_mesh: Mesh)
     assert result.outputs.dtype == inputs.dtype
     _assert_close(result=result.outputs, reference=_reference(module, inputs))
     _assert_named_sharding(result.outputs.sharding, fake_mesh)
+
+
+def test_separable_causal_conv_match_weights_preserves_state_dtype(fake_mesh: Mesh) -> None:
+    module = _conv()
+    state = _sharded_sequence(
+        jnp.array([[10.0, 11.0, 12.0, 13.0], [14.0, 15.0, 16.0, 17.0]], dtype=jnp.bfloat16),
+    )
+    inputs = _sharded_sequence(jnp.arange(4 * CHANNELS, dtype=jnp.bfloat16).reshape(4, CHANNELS) / 10)
+
+    result = module(
+        inputs,
+        length_without_padding=2,
+        state=state,
+        return_updated_state=True,
+        precision=ConvPrecision.MATCH_WEIGHTS,
+    )
+
+    assert result.state is not None
+    assert result.outputs.dtype == module.weights.dtype
+    assert result.state.dtype == state.dtype
+    history = jnp.concatenate((state, inputs), axis=0).astype(module.weights.dtype)
+    windows = jnp.stack([history[token : token + module.kernel_size] for token in range(inputs.shape[0])])
+    reference = jnp.einsum("tkc,ck->tc", windows, module.weights)
+    assert module.biases is not None
+    reference = reference + module.biases
+    _assert_close(result=result.outputs, reference=reference)
+    _assert_close(result=result.state, reference=jnp.asarray(jax.device_get(inputs))[:2])
+    _assert_named_sharding(result.outputs.sharding, fake_mesh)
+    _assert_named_sharding(result.state.sharding, fake_mesh)
 
 
 def test_separable_causal_conv_updates_state_from_unpadded_suffix(fake_mesh: Mesh) -> None:
@@ -234,15 +263,10 @@ def test_separable_causal_conv_vmapped_gradient_under_explicit_mesh(fake_mesh: M
 
 def test_separable_causal_conv_export_load_roundtrips_with_replicated_parameters(fake_mesh: Mesh) -> None:
     original = _conv()
-    weight_sharding = make_sharding((None, None))
-    bias_sharding = make_sharding((None,))
-    template = SeparableCausalConv(
-        config=original.config,
-        sharding_config=make_test_sharding_config(),
-        weights=dummy_array(original.weights.shape, original.weights.dtype, weight_sharding),
-        biases=dummy_array(original.biases.shape, original.biases.dtype, bias_sharding)
-        if original.biases is not None
-        else None,
+    template = original.config.init(
+        EmptyInitializer(default_dtype=jnp.bfloat16, sharding_config=make_test_sharding_config()),
+        input_dim=original.input_dim,
+        kernel_size=original.kernel_size,
     )
     inputs = _sharded_sequence(jnp.arange(5 * CHANNELS, dtype=jnp.float32).reshape(5, CHANNELS) / 10)
 
@@ -250,9 +274,11 @@ def test_separable_causal_conv_export_load_roundtrips_with_replicated_parameters
     result = restored(inputs)
 
     assert restored.weights.sharding == make_sharding((None, None))
+    assert restored.weights.dtype == jnp.float32
     assert restored.biases is not None
     assert template.biases is not None
     assert restored.biases.sharding == make_sharding((None,))
+    assert restored.biases.dtype == jnp.float32
     _assert_named_sharding(restored.weights.sharding, fake_mesh)
     _assert_named_sharding(restored.biases.sharding, fake_mesh)
     _assert_close(result=result.outputs, reference=original(inputs).outputs)

--- a/tests/unit/modules/test_normalization.py
+++ b/tests/unit/modules/test_normalization.py
@@ -4,10 +4,10 @@ import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, Sharding
 from jaxtyping import Array
 
+from lalamo.initializer import EmptyInitializer
 from lalamo.module import LogicalAxis
 from lalamo.modules.normalization import Normalization, NormalizationConfig, UpcastMode
 from lalamo.modules.utils import call_vmapped
-from lalamo.utils.dummy_array import dummy_array
 from tests.common import assert_close
 from tests.helpers import make_sharding, make_test_sharding_config
 
@@ -165,14 +165,9 @@ def test_normalization_vmapped_over_inputs_matches_reference_and_keeps_data_shar
 
 def test_normalization_export_load_roundtrips_and_preserves_template_sharding(fake_mesh: Mesh) -> None:
     original = _normalization()
-    parameter_sharding = make_sharding((None,))
-    template = Normalization(
-        config=original.config,
-        sharding_config=make_test_sharding_config(),
-        scales=dummy_array(original.scales.shape, original.scales.dtype, parameter_sharding),
-        biases=dummy_array(original.biases.shape, original.biases.dtype, parameter_sharding)
-        if original.biases is not None
-        else None,
+    template = original.config.init(
+        EmptyInitializer(default_dtype=jnp.bfloat16, sharding_config=make_test_sharding_config()),
+        input_dim=original.input_dim,
     )
     inputs = _sharded_input(jnp.array([1.0, -2.0, 3.0, -4.0], dtype=jnp.float32))
 
@@ -180,11 +175,13 @@ def test_normalization_export_load_roundtrips_and_preserves_template_sharding(fa
     result = restored(inputs)
 
     assert restored.scales.sharding == template.scales.sharding
+    assert restored.scales.dtype == jnp.float32
     assert isinstance(restored.scales.sharding, NamedSharding)
     assert restored.scales.sharding.mesh == fake_mesh
     assert restored.biases is not None
     assert template.biases is not None
     assert restored.biases.sharding == template.biases.sharding
+    assert restored.biases.dtype == jnp.float32
     _assert_close(result=result, reference=original(inputs))
     _assert_named_sharding(result.sharding, fake_mesh)
     assert result.sharding == make_sharding((None,))

--- a/tests/unit/test_exportable.py
+++ b/tests/unit/test_exportable.py
@@ -38,7 +38,6 @@ class CustomLeaf(Exportable, eqx.Module):
     def load_exported(
         self,
         exported_data: ExportResults,
-        allow_dtype_cast: bool = False,  # noqa: ARG002
         *,
         prefix: ParameterPath | None = None,
     ) -> Self:
@@ -153,16 +152,6 @@ def test_load_exported_rejects_dtype_mismatch_by_default() -> None:
 
     with pytest.raises(ValueError, match="dtype"):
         skeleton.load_exported(exported)
-
-
-def test_load_exported_casts_dtype_when_allowed() -> None:
-    skeleton = Leaf(weight=jnp.zeros((2,), dtype=jnp.float32), bias=None)
-    exported = ExportResults(arrays={"weight": jnp.ones((2,), dtype=jnp.float16)}, metadata={})
-
-    restored = skeleton.load_exported(exported, allow_dtype_cast=True)
-
-    assert restored.weight.dtype == jnp.float32
-    assert jnp.array_equal(restored.weight, jnp.ones((2,), dtype=jnp.float32))
 
 
 def test_load_exported_preserves_template_sharding() -> None:

--- a/tests/unit/test_exportable.py
+++ b/tests/unit/test_exportable.py
@@ -134,7 +134,7 @@ def test_load_exported_uses_prefix() -> None:
 def test_load_exported_reports_missing_array() -> None:
     skeleton = Leaf(weight=jnp.zeros((2,), dtype=jnp.float32), bias=None)
 
-    with pytest.raises(KeyError, match="weight"):
+    with pytest.raises(ValueError, match="weight"):
         skeleton.load_exported(ExportResults(arrays={}, metadata={}))
 
 

--- a/tests/unit/test_exportable.py
+++ b/tests/unit/test_exportable.py
@@ -146,12 +146,14 @@ def test_load_exported_rejects_shape_mismatch() -> None:
         skeleton.load_exported(exported)
 
 
-def test_load_exported_rejects_dtype_mismatch_by_default() -> None:
+def test_load_exported_casts_to_strong_skeleton_dtype() -> None:
     skeleton = Leaf(weight=jnp.zeros((2,), dtype=jnp.float32), bias=None)
-    exported = ExportResults(arrays={"weight": jnp.ones((2,), dtype=jnp.float16)}, metadata={})
+    exported = ExportResults(arrays={"weight": jnp.ones((2,), dtype=jnp.bfloat16)}, metadata={})
 
-    with pytest.raises(ValueError, match="dtype"):
-        skeleton.load_exported(exported)
+    restored = skeleton.load_exported(exported)
+
+    assert restored.weight.dtype == jnp.float32
+    assert jnp.array_equal(restored.weight, jnp.ones((2,), dtype=jnp.float32))
 
 
 def test_load_exported_preserves_template_sharding() -> None:

--- a/tests/unit/test_model_import_loading.py
+++ b/tests/unit/test_model_import_loading.py
@@ -80,8 +80,8 @@ def _mlx_weights(path: ParameterPath) -> Mapping[str, Array]:
     unpacked_weights = jnp.arange(OUTPUT_DIM * INPUT_DIM, dtype=jnp.int32).reshape(OUTPUT_DIM, INPUT_DIM)
     return {
         path / "weight": _pack_int32(unpacked_weights, bits=8),
-        path / "scales": jnp.ones((OUTPUT_DIM, NUM_GROUPS), dtype=jnp.float32),
-        path / "biases": jnp.zeros((OUTPUT_DIM, NUM_GROUPS), dtype=jnp.float32),
+        path / "scales": jnp.ones((OUTPUT_DIM, NUM_GROUPS), dtype=jnp.bfloat16),
+        path / "biases": jnp.zeros((OUTPUT_DIM, NUM_GROUPS), dtype=jnp.bfloat16),
     }
 
 
@@ -91,7 +91,7 @@ def _awq_weights(path: ParameterPath) -> Mapping[str, Array]:
     return {
         path / "qweight": _pack_int32(unpacked_weights, bits=8),
         path / "qzeros": _pack_int32(unpacked_zero_points, bits=8),
-        path / "scales": jnp.ones((NUM_GROUPS, OUTPUT_DIM), dtype=jnp.float32),
+        path / "scales": jnp.ones((NUM_GROUPS, OUTPUT_DIM), dtype=jnp.bfloat16),
     }
 
 
@@ -99,7 +99,7 @@ def _symmetric_awq_weights(path: ParameterPath) -> Mapping[str, Array]:
     unpacked_weights = jnp.arange(INPUT_DIM * OUTPUT_DIM, dtype=jnp.int32).reshape(INPUT_DIM, OUTPUT_DIM) + 128
     return {
         path / "qweight": _pack_int32(unpacked_weights, bits=8),
-        path / "scales": jnp.ones((NUM_GROUPS, OUTPUT_DIM), dtype=jnp.float32),
+        path / "scales": jnp.ones((NUM_GROUPS, OUTPUT_DIM), dtype=jnp.bfloat16),
     }
 
 

--- a/tests/unit/test_model_import_loading.py
+++ b/tests/unit/test_model_import_loading.py
@@ -283,10 +283,6 @@ class TinyModel(Model[ChatCodecConfig, TinyModelConfig, ChatCodec]):
 
 @dataclass(frozen=True)
 class TinyForeignConfig(ForeignConfig[TinyModelConfig]):
-    @property
-    def default_dtype(self) -> DTypeLike:
-        return jnp.float32
-
     def _load_weights(
         self,
         model: Model,

--- a/tests/unit/test_model_import_loading.py
+++ b/tests/unit/test_model_import_loading.py
@@ -252,11 +252,15 @@ class TinyConfig(LalamoConfig):
             config=self,
             sharding_config=make_test_sharding_config(),
             matrix=initializer.weight_matrix(output_dim=4, input_dim=4),
+            fp8_values=initializer.zeros((4,)),
+            fp16_values=initializer.zeros((4,)),
         )
 
 
 class TinyModule(LalamoModule[TinyConfig]):
     matrix: WeightMatrix
+    fp8_values: Array
+    fp16_values: Array
 
 
 @dataclass(frozen=True)
@@ -303,6 +307,8 @@ class TinyForeignConfig(ForeignConfig[TinyModelConfig]):
                     implementation=implementation,
                     sharding_config=make_test_sharding_config(),
                 ),
+                fp8_values=model.module.fp8_values,
+                fp16_values=model.module.fp16_values,
             ),
         )
 
@@ -336,9 +342,8 @@ def test_foreign_config_load_initializes_model_with_requested_dtype_and_implemen
     assert loaded.module.matrix.dtype == jnp.bfloat16
 
 
-def test_model_export_load_preserves_saved_dtype(tmp_path: Path) -> None:
-    tokenizer = Tokenizer(WordLevel(vocab={"[UNK]": 0}, unk_token="[UNK]"))
-    config = TinyModelConfig(
+def _tiny_model_config() -> TinyModelConfig:
+    return TinyModelConfig(
         token_codec_config=ChatCodecConfig(
             prompt_template="",
             output_parser_regex=None,
@@ -350,7 +355,17 @@ def test_model_export_load_preserves_saved_dtype(tmp_path: Path) -> None:
         ),
         module_config=TinyConfig(),
     )
-    original = TinyModel(
+
+
+def _tiny_model_with_dtypes(
+    tokenizer: Tokenizer,
+    *,
+    matrix_dtype: DTypeLike = jnp.float32,
+    fp8_values_dtype: DTypeLike = jnp.float8_e4m3fn,
+    fp16_values_dtype: DTypeLike = jnp.float16,
+) -> TinyModel:
+    config = _tiny_model_config()
+    return TinyModel(
         config=config,
         sharding_config=make_test_sharding_config(),
         token_codec=config.token_codec_config.init(tokenizer),
@@ -358,11 +373,18 @@ def test_model_export_load_preserves_saved_dtype(tmp_path: Path) -> None:
             config=TinyConfig(),
             sharding_config=make_test_sharding_config(),
             matrix=IntSpec(bits=8, group_size=2).compress(
-                jnp.arange(16, dtype=jnp.float32).reshape(4, 4),
+                jnp.arange(16, dtype=matrix_dtype).reshape(4, 4),
                 sharding_config=make_test_sharding_config(),
             ),
+            fp8_values=jnp.arange(4, dtype=fp8_values_dtype),
+            fp16_values=jnp.arange(4, dtype=fp16_values_dtype),
         ),
     )
+
+
+def test_model_export_load_with_weak_initializer_preserves_saved_float_dtypes(tmp_path: Path) -> None:
+    tokenizer = Tokenizer(WordLevel(vocab={"[UNK]": 0}, unk_token="[UNK]"))
+    original = _tiny_model_with_dtypes(tokenizer)
 
     original.save(tmp_path)
     restored = TinyModel.load(tmp_path, sharding_config=make_test_sharding_config())
@@ -370,3 +392,36 @@ def test_model_export_load_preserves_saved_dtype(tmp_path: Path) -> None:
     assert isinstance(restored.module.matrix, IntMatrixForInference)
     assert restored.module.matrix.spec == original.module.matrix.spec
     assert restored.module.matrix.dtype == original.module.matrix.dtype
+    assert restored.module.fp8_values.dtype == jnp.float8_e4m3fn
+    assert restored.module.fp16_values.dtype == jnp.float16
+
+
+def test_model_export_load_with_strong_initializer_requires_saved_dtype_match(tmp_path: Path) -> None:
+    tokenizer = Tokenizer(WordLevel(vocab={"[UNK]": 0}, unk_token="[UNK]"))
+    matching = _tiny_model_with_dtypes(
+        tokenizer,
+        matrix_dtype=jnp.float16,
+        fp8_values_dtype=jnp.float16,
+        fp16_values_dtype=jnp.float16,
+    )
+    matching_path = tmp_path / "matching"
+    matching.save(matching_path)
+
+    restored = TinyModel.load(matching_path, dtype=jnp.float16, sharding_config=make_test_sharding_config())
+
+    assert isinstance(restored.module.matrix, IntMatrixForInference)
+    assert restored.module.matrix.dtype == jnp.float16
+    assert restored.module.fp8_values.dtype == jnp.float16
+    assert restored.module.fp16_values.dtype == jnp.float16
+
+    mismatched = _tiny_model_with_dtypes(
+        tokenizer,
+        matrix_dtype=jnp.float16,
+        fp8_values_dtype=jnp.float8_e4m3fn,
+        fp16_values_dtype=jnp.float16,
+    )
+    mismatched_path = tmp_path / "mismatched"
+    mismatched.save(mismatched_path)
+
+    with pytest.raises(ValueError, match="dtype"):
+        TinyModel.load(mismatched_path, dtype=jnp.float16, sharding_config=make_test_sharding_config())

--- a/tests/unit/test_model_import_loading.py
+++ b/tests/unit/test_model_import_loading.py
@@ -15,7 +15,10 @@ from lalamo.compressed.int import IntMatrixForInference, IntMatrixForTraining, I
 from lalamo.compressed.mlx import MLXMatrixForInference, MLXMatrixForTraining
 from lalamo.initializer import EmptyInitializer, Initializer
 from lalamo.model import Model, ModelConfig
-from lalamo.model_import.loaders.huggingface import load_huggingface_classifier, load_linear
+from lalamo.model_import.loaders.huggingface import (
+    load_huggingface_classifier,
+    load_linear,
+)
 from lalamo.model_import.model_configs.foreign_config import ForeignConfig
 from lalamo.model_import.model_configs.huggingface import ModernBERTConfig
 from lalamo.models.chat_codec import ChatCodec, ChatCodecConfig
@@ -27,7 +30,13 @@ from lalamo.modules.mlp import DenseMLP
 from lalamo.modules.token_mixers.attention import Attention
 from lalamo.utils.dummy_array import dummy_array
 from lalamo.utils.parameter_path import ParameterPath
-from lalamo.weight_matrix import CompressionImplementation, FullPrecisionSpec, Layout, WeightMatrix
+from lalamo.weight_matrix import (
+    CompressionImplementation,
+    FullPrecisionMatrix,
+    FullPrecisionSpec,
+    Layout,
+    WeightMatrix,
+)
 from tests.helpers import make_sharding, make_test_sharding_config
 
 pytestmark = pytest.mark.usefixtures("fake_mesh")
@@ -50,7 +59,7 @@ def _pack_int32(values: Array, bits: int) -> Array:
     return jnp.sum(grouped << shifts, axis=-1, dtype=jnp.uint32).astype(jnp.int32)
 
 
-def _linear_template(dtype: DTypeLike, layout: Layout = Layout.OUTPUT_INPUT) -> Linear:
+def _linear_template(dtype: DTypeLike | None, layout: Layout = Layout.OUTPUT_INPUT) -> Linear:
     result = LinearConfig().init(
         initializer=EmptyInitializer(default_dtype=dtype, sharding_config=make_test_sharding_config()),
         input_dim=INPUT_DIM,
@@ -228,6 +237,34 @@ def test_load_linear_symmetric_awq_without_qzeros_uses_symmetric_spec() -> None:
     assert loaded.weights.packed_zero_points is None
 
 
+def test_load_linear_full_precision_weak_template_preserves_checkpoint_dtype() -> None:
+    path = ParameterPath("layer")
+    weights = jnp.arange(OUTPUT_DIM * INPUT_DIM, dtype=jnp.float32).reshape(OUTPUT_DIM, INPUT_DIM).astype(jnp.bfloat16)
+
+    loaded = load_linear(
+        _linear_template(None),
+        {path / "weight": weights},
+        path,
+    )
+
+    assert isinstance(loaded.weights, FullPrecisionMatrix)
+    assert loaded.weights.dtype == jnp.bfloat16
+
+
+def test_load_linear_full_precision_strong_template_forces_template_dtype() -> None:
+    path = ParameterPath("layer")
+    weights = jnp.arange(OUTPUT_DIM * INPUT_DIM, dtype=jnp.float32).reshape(OUTPUT_DIM, INPUT_DIM).astype(jnp.bfloat16)
+
+    loaded = load_linear(
+        _linear_template(jnp.float32),
+        {path / "weight": weights},
+        path,
+    )
+
+    assert isinstance(loaded.weights, FullPrecisionMatrix)
+    assert loaded.weights.dtype == jnp.float32
+
+
 def test_load_huggingface_classifier_uses_hf_embedding_layout() -> None:
     classifier = _classifier_template()
     weights = _classifier_weights(classifier)
@@ -392,32 +429,14 @@ def test_model_export_load_with_weak_initializer_preserves_saved_float_dtypes(tm
     assert restored.module.fp16_values.dtype == jnp.float16
 
 
-def test_model_export_load_with_strong_initializer_requires_saved_dtype_match(tmp_path: Path) -> None:
+def test_model_export_load_with_strong_initializer_forces_saved_float_dtypes(tmp_path: Path) -> None:
     tokenizer = Tokenizer(WordLevel(vocab={"[UNK]": 0}, unk_token="[UNK]"))
-    matching = _tiny_model_with_dtypes(
-        tokenizer,
-        matrix_dtype=jnp.float16,
-        fp8_values_dtype=jnp.float16,
-        fp16_values_dtype=jnp.float16,
-    )
-    matching_path = tmp_path / "matching"
-    matching.save(matching_path)
+    original = _tiny_model_with_dtypes(tokenizer)
+    original.save(tmp_path)
 
-    restored = TinyModel.load(matching_path, dtype=jnp.float16, sharding_config=make_test_sharding_config())
+    restored = TinyModel.load(tmp_path, dtype=jnp.bfloat16, sharding_config=make_test_sharding_config())
 
     assert isinstance(restored.module.matrix, IntMatrixForInference)
-    assert restored.module.matrix.dtype == jnp.float16
-    assert restored.module.fp8_values.dtype == jnp.float16
-    assert restored.module.fp16_values.dtype == jnp.float16
-
-    mismatched = _tiny_model_with_dtypes(
-        tokenizer,
-        matrix_dtype=jnp.float16,
-        fp8_values_dtype=jnp.float8_e4m3fn,
-        fp16_values_dtype=jnp.float16,
-    )
-    mismatched_path = tmp_path / "mismatched"
-    mismatched.save(mismatched_path)
-
-    with pytest.raises(ValueError, match="dtype"):
-        TinyModel.load(mismatched_path, dtype=jnp.float16, sharding_config=make_test_sharding_config())
+    assert restored.module.matrix.dtype == jnp.bfloat16
+    assert restored.module.fp8_values.dtype == jnp.bfloat16
+    assert restored.module.fp16_values.dtype == jnp.bfloat16

--- a/tests/unit/test_model_import_loading.py
+++ b/tests/unit/test_model_import_loading.py
@@ -336,7 +336,7 @@ def test_foreign_config_load_initializes_model_with_requested_dtype_and_implemen
     assert loaded.module.matrix.dtype == jnp.bfloat16
 
 
-def test_model_export_load_uses_saved_weight_matrix_spec_with_shape_dtype_template(tmp_path: Path) -> None:
+def test_model_export_load_preserves_saved_dtype(tmp_path: Path) -> None:
     tokenizer = Tokenizer(WordLevel(vocab={"[UNK]": 0}, unk_token="[UNK]"))
     config = TinyModelConfig(
         token_codec_config=ChatCodecConfig(
@@ -366,13 +366,7 @@ def test_model_export_load_uses_saved_weight_matrix_spec_with_shape_dtype_templa
 
     original.save(tmp_path)
     restored = TinyModel.load(tmp_path, sharding_config=make_test_sharding_config())
-    restored_float32 = TinyModel.load(
-        tmp_path,
-        dtype=jnp.float32,
-        sharding_config=make_test_sharding_config(),
-    )
 
     assert isinstance(restored.module.matrix, IntMatrixForInference)
     assert restored.module.matrix.spec == original.module.matrix.spec
-    assert restored.module.matrix.dtype == jnp.bfloat16
-    assert restored_float32.module.matrix.dtype == jnp.float32
+    assert restored.module.matrix.dtype == original.module.matrix.dtype

--- a/tests/unit/utils/test_surgery.py
+++ b/tests/unit/utils/test_surgery.py
@@ -53,10 +53,9 @@ def test_load_as_loads_matching_array_tree() -> None:
     [
         ({"weight": jnp.zeros((2, 3))}, {"weight": jnp.ones((2, 3)), "bias": jnp.ones((2,))}, TypeError, "pytree"),
         (jnp.zeros((2, 3), dtype=jnp.float32), jnp.ones((2, 4), dtype=jnp.float32), ValueError, "shape"),
-        (jnp.zeros((2, 3), dtype=jnp.float32), jnp.ones((2, 3), dtype=jnp.float16), ValueError, "dtype"),
         ({"name": "linear"}, {"name": 1}, TypeError, "type"),
         (_matrix(shape=(2, 3)), _matrix(shape=(2, 4), fill_value=1), ValueError, "shape"),
-        (_matrix(dtype=jnp.float32), _matrix(dtype=jnp.float16, fill_value=1), ValueError, "dtype"),
+        (_matrix(dtype=jnp.float32), _matrix(dtype=jnp.bfloat16, fill_value=1), ValueError, "dtype"),
     ],
 )
 def test_load_as_rejects_mismatches(template: PyTree, value: PyTree, error: type[Exception], match: str) -> None:
@@ -64,12 +63,23 @@ def test_load_as_rejects_mismatches(template: PyTree, value: PyTree, error: type
         load_as(template, value)
 
 
-def test_load_as_uses_strict_dtype_promotion_for_compatibility_check() -> None:
+def test_load_as_casts_strong_template_array_dtype_under_strict_promotion() -> None:
     template = jnp.zeros((2, 3), dtype=jnp.float32)
-    value = jnp.ones((2, 3), dtype=jnp.float16)
+    value = jnp.ones((2, 3), dtype=jnp.bfloat16)
 
-    with jax.numpy_dtype_promotion("standard"), pytest.raises(ValueError, match="dtype"):
-        load_as(template, value)
+    with jax.numpy_dtype_promotion("strict"):
+        result = load_as(template, value)
+
+    assert result.dtype == jnp.float32
+
+
+def test_load_as_uses_value_dtype_for_weak_template_arrays() -> None:
+    template = dummy_array((2, 3), None, make_sharding((None, None)))
+    value = jnp.ones((2, 3), dtype=jnp.bfloat16)
+
+    result = load_as(template, value)
+
+    assert result.dtype == jnp.bfloat16
 
 
 def test_load_as_treats_weight_matrices_as_leaf_nodes() -> None:

--- a/tests/unit/utils/test_surgery.py
+++ b/tests/unit/utils/test_surgery.py
@@ -64,6 +64,14 @@ def test_load_as_rejects_mismatches(template: PyTree, value: PyTree, error: type
         load_as(template, value)
 
 
+def test_load_as_uses_strict_dtype_promotion_for_compatibility_check() -> None:
+    template = jnp.zeros((2, 3), dtype=jnp.float32)
+    value = jnp.ones((2, 3), dtype=jnp.float16)
+
+    with jax.numpy_dtype_promotion("standard"), pytest.raises(ValueError, match="dtype"):
+        load_as(template, value)
+
+
 def test_load_as_treats_weight_matrices_as_leaf_nodes() -> None:
     template = {"matrix": _matrix()}
     value = {"matrix": _matrix(fill_value=1)}

--- a/tests/unit/utils/test_surgery.py
+++ b/tests/unit/utils/test_surgery.py
@@ -64,13 +64,6 @@ def test_load_as_rejects_mismatches(template: PyTree, value: PyTree, error: type
         load_as(template, value)
 
 
-def test_load_as_casts_array_dtype_when_allowed() -> None:
-    result = load_as(jnp.zeros((2, 3), dtype=jnp.float32), jnp.ones((2, 3), dtype=jnp.float16), allow_dtype_cast=True)
-
-    assert result.dtype == jnp.float32
-    assert jnp.all(result == 1)
-
-
 def test_load_as_treats_weight_matrices_as_leaf_nodes() -> None:
     template = {"matrix": _matrix()}
     value = {"matrix": _matrix(fill_value=1)}
@@ -111,17 +104,6 @@ def test_load_as_uses_template_replicated_sharding_without_host_roundtrip(fake_m
     assert result.sharding != source_sharding
     assert jnp.array_equal(result, value)
     del fake_mesh
-
-
-def test_load_as_casts_weight_matrix_dtype_when_allowed() -> None:
-    template = _matrix(dtype=jnp.float32)
-    value = _matrix(dtype=jnp.float16, fill_value=1)
-
-    result = load_as(template, value, allow_dtype_cast=True)
-
-    assert isinstance(result, FullPrecisionMatrix)
-    assert result.dtype == jnp.float32
-    assert jnp.all(result.weights == 1)
 
 
 def test_map_nodes_of_type_updates_only_selected_nodes() -> None:


### PR DESCRIPTION
I'm actually kinda proud; so basically what happens now is:

1. Initializers can take None as default dtype, which will make them "weakly typed" - ala support any floats.
2. If an Initializer for a module is strongly typed, then when trying to load a differently dtyped arrays into its params, it will loudly blow up
3. If an initializer is weakly typed, then it will blow up when trying to load a non-convertible dtype in its place (so bf16 -> fp32 is fine, but like fp16 -> bf16 is not)
4. By default initializers are weakly typed - this is because otherwise the experimentations with different things is very painful, and in general i assume this is the "preferred" behaviour. But if one wants to be strict when using lalamo as a library, one always can - tho I'm not sure what exactly would be the point... @norpadon - not sure tbh, basically if I force bfloat16 by default we get failures for mlx models + a few others that use f32 somewhere. I don't see a clean way to adapt to these things, however... Like maybe we could override the "default_dtype" of an initializer somehow for some models, but I remember you being against it. I generally prefer to have a weak type as default tbh

And finally, I enabled strict typing! awesome! basically no more implicit dtype promotions in jax, which means everything is quite a bit more predictable in terms of types
