### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/lalamo/__init__.py
+++ b/lalamo/__init__.py
@@ -26,7 +26,7 @@ from lalamo.models.chat_codec import (
     UserMessage,
 )
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 
 __all__ = [
     "AssistantMessage",


### PR DESCRIPTION
This PR bumps __version__ in lalamo/__init__.py to 0.13.0.