### PR TITLE
Fix padded-token leak in MoE ragged_dot prefill

### DIFF
--- a/lalamo/modules/mlp.py
+++ b/lalamo/modules/mlp.py
@@ -549,6 +549,14 @@ class MixtureOfExperts(MLPBase[MixtureOfExpertsConfig]):
         routed_token_indices = routed_assignment_indices // num_active_routed_experts
         routed_expert_indices = routed_expert_indices[routed_assignment_indices]
         routed_weights = active_expert_weights.ravel()[routed_assignment_indices]
+        # Padded (token, expert) pairs are routed to the sentinel expert id ``num_routed_experts`` and
+        # dropped from the ragged_dot groups, but ragged_dot still emits nonzero rows for that ungrouped
+        # tail. Zero their routing weights so padded tokens contribute nothing to the scatter below.
+        routed_weights = jnp.where(
+            routed_expert_indices < self.config.num_routed_experts,
+            routed_weights,
+            0.0,
+        )
         routed_group_sizes = with_sharding(routed_group_sizes, make_sharding((ShardingAxis.EXPERT,)))
 
         routed_input_source = with_sharding(flattened_inputs, make_sharding((None, None)))

--- a/tests/unit/modules/test_mlp.py
+++ b/tests/unit/modules/test_mlp.py
@@ -649,6 +649,31 @@ def test_routed_moe_output_dtype_matches_input_dtype(fake_mesh: Mesh, mode: Forw
     assert result.dtype == inputs.dtype
 
 
+def test_moe_prefill_routed_only_with_padding_zeroes_padded_tokens(fake_mesh: Mesh) -> None:
+    # Regression for the padded-token leak: padded (token, expert) pairs are routed to the sentinel
+    # expert and dropped from the ragged_dot groups, but ragged_dot still emits nonzero rows for that
+    # ungrouped tail. Their routing weights must be zeroed so padded positions stay exactly zero. This
+    # bug lives in the routed path alone and does not require shared experts to reproduce.
+    assert fake_mesh is not None
+    module = _routed_only_moe(num_active_routed_experts=2)
+    inputs = jnp.arange(2 * 3 * MODEL_DIM, dtype=jnp.float32).reshape(2, 3, MODEL_DIM) / 10
+    lengths_without_padding = jnp.array([3, 1], dtype=jnp.int32)
+
+    result = module(
+        inputs,
+        lengths_without_padding=lengths_without_padding,
+        forward_pass_config=MLPForwardPassConfig(moe_chunk_size_ratio=0.5),
+        keychain=Keychain.init(9),
+    )
+
+    _assert_close(
+        result=result,
+        reference=_routed_moe_reference(module, inputs, lengths_without_padding=lengths_without_padding),
+    )
+    # Padded positions (batch 1, tokens 1 and 2) must be exactly zero, not merely close.
+    assert jnp.all(jnp.asarray(jax.device_get(result))[1, 1:] == 0)
+
+
 def test_moe_prefill_with_shared_experts_and_padding_matches_direct_reference(fake_mesh: Mesh) -> None:
     assert fake_mesh is not None
     module = _moe(num_active_routed_experts=2, num_shared_experts=2)


### PR DESCRIPTION
Targets #248 (`norpadon/replace-moe-with-raggeddot`) and fixes its two failing padding tests.

## Problem
In `MixtureOfExperts.call_prefill_mode`, padded `(token, expert)` pairs are routed to the sentinel expert id `num_routed_experts` and excluded from the `ragged_dot` `group_sizes`, leaving them as an ungrouped tail beyond `sum(group_sizes)`. `lax.ragged_dot`'s output for those tail rows is unspecified and platform dependent — nonzero on CPU, zero on GPU (verified on CPU and B200). On CPU the nonzero rows get scattered back into the padded token slots with their (nonzero) routing weights, leaking a ~9.6 magnitude value into positions the reference defines as exactly `0`. This fails:
- `test_moe_prefill_with_shared_experts_and_padding_matches_direct_reference`
- `test_moe_prefill_with_gated_shared_experts_matches_direct_reference`

## Fix
Zero the routing weight of sentinel entries so padded tokens contribute nothing to the scatter, regardless of backend. Valid-token outputs and expert-parallel sharding are unchanged.

## Tests
- Adds `test_moe_prefill_routed_only_with_padding_zeroes_padded_tokens` — the bug reproduces in the routed-only path (shared experts are not required); asserts padded positions are exactly `0`.
- `tests/unit/modules/test_mlp.py`, `test_linear.py`, `test_weight_matrix.py`: 78 passed.
- Padded output is exactly `0` on both an 8-device sharded mesh and single device; result is sharding-invariant.
