### PR TITLE
Cache resident model and auto-batch probe across /batches requests

### DIFF
--- a/lalamo/inference/batch_scheduler.py
+++ b/lalamo/inference/batch_scheduler.py
@@ -32,7 +32,6 @@ __all__ = [
     "ContinuousBatchScheduler",
     "FixedSizeBatchScheduler",
     "GeneratedSequence",
-    "clear_probe_cache",
     "estimate_batchsize_for_memory_budget",
 ]
 
@@ -45,10 +44,6 @@ MAX_BOUNDARY_BATCH_PADDING_FRACTION: float = 0.05
 # Auto-batch probe results {(id(model), vram, max_output_length): {padded_length: batch_size}}: lets a
 # resident server skip the throwaway probe compiles. Keyed on max_output_length since state_capacity scales with it.
 _PROBE_CACHE: dict[tuple[int, int, int], dict[int, int]] = {}
-
-
-def clear_probe_cache() -> None:
-    _PROBE_CACHE.clear()
 
 
 @dataclass(frozen=True)
@@ -238,16 +233,14 @@ def bucket_sequences[T: TokenSequence](
 
     for idx, padded_length in enumerate(sorted_lengths):
         # Reuse a cached batch size for this padded_length (the probe's throwaway compiles dominate latency).
-        if padded_length in probe_cache:
-            estimated = probe_cache[padded_length]
-        else:
-            estimated = estimate_batchsize_for_memory_budget(
+        if padded_length not in probe_cache:
+            probe_cache[padded_length] = estimate_batchsize_for_memory_budget(
                 functools.partial(memory_probe, padded_length=padded_length),
                 memory_budget=max_vram,
                 starting_batchsize=estimated,
                 num_steps=num_steps,
             )
-            probe_cache[padded_length] = estimated
+        estimated = probe_cache[padded_length]
 
         # 1 estimator step suffices for each consecutive estimation, since we will already have
         # ~80% VRAM allocation ratio by starting from the last batchsize estimate, and 1 step is enough
@@ -821,9 +814,8 @@ class BatchScheduler(ABC):
                     jax.block_until_ready(first_result)
 
             max_vram = _memory_budget_for_auto_batching(vram_bytes)
-            probe_cache = _PROBE_CACHE.setdefault(
-                (id(self.model), max_vram, batch_scheduler_config.max_output_length), {}
-            )
+            probe_cache_key = (id(self.model), max_vram, batch_scheduler_config.max_output_length)
+            probe_cache = _PROBE_CACHE.setdefault(probe_cache_key, {})
             sequences_per_bucket, batch_size_per_bucket = bucket_sequences(
                 tokenized,
                 memory_probe,

--- a/lalamo/inference/batch_scheduler.py
+++ b/lalamo/inference/batch_scheduler.py
@@ -41,10 +41,12 @@ PROMPT_SIZE_BUCKETS: tuple[int, ...] = tuple(256 * 4**i for i in range(8))
 MIN_BATCHES_PER_BUCKET: int = 10
 MAX_BOUNDARY_BATCH_PADDING_FRACTION: float = 0.05
 
-# Cache of auto-batch probe results, keyed by (id(model), vram_bytes) -> {padded_length: batch_size}.
-# Lets a resident server skip re-running the expensive probe (throwaway compiles + forwards) for
-# shapes it has already measured. Keyed on model identity so a different/reloaded model re-probes.
-_PROBE_CACHE: dict[tuple[int, int], dict[int, int]] = {}
+# Cache of auto-batch probe results, keyed by (id(model), vram_bytes, max_output_length) ->
+# {padded_length: batch_size}. Lets a resident server skip re-running the expensive probe (throwaway
+# compiles + forwards) for shapes it has already measured. Keyed on model identity so a
+# different/reloaded model re-probes, and on max_output_length since the KV/buffer memory the probe
+# sizes against scales with it (state_capacity = padded_length + max_output_length + 1).
+_PROBE_CACHE: dict[tuple[int, int, int], dict[int, int]] = {}
 
 
 @dataclass(frozen=True)
@@ -820,7 +822,9 @@ class BatchScheduler(ABC):
                     jax.block_until_ready(first_result)
 
             max_vram = _memory_budget_for_auto_batching(vram_bytes)
-            probe_cache = _PROBE_CACHE.setdefault((id(self.model), max_vram), {})
+            probe_cache = _PROBE_CACHE.setdefault(
+                (id(self.model), max_vram, batch_scheduler_config.max_output_length), {}
+            )
             sequences_per_bucket, batch_size_per_bucket = bucket_sequences(
                 tokenized,
                 memory_probe,

--- a/lalamo/inference/batch_scheduler.py
+++ b/lalamo/inference/batch_scheduler.py
@@ -32,6 +32,7 @@ __all__ = [
     "ContinuousBatchScheduler",
     "FixedSizeBatchScheduler",
     "GeneratedSequence",
+    "clear_probe_cache",
     "estimate_batchsize_for_memory_budget",
 ]
 
@@ -41,12 +42,13 @@ PROMPT_SIZE_BUCKETS: tuple[int, ...] = tuple(256 * 4**i for i in range(8))
 MIN_BATCHES_PER_BUCKET: int = 10
 MAX_BOUNDARY_BATCH_PADDING_FRACTION: float = 0.05
 
-# Cache of auto-batch probe results, keyed by (id(model), vram_bytes, max_output_length) ->
-# {padded_length: batch_size}. Lets a resident server skip re-running the expensive probe (throwaway
-# compiles + forwards) for shapes it has already measured. Keyed on model identity so a
-# different/reloaded model re-probes, and on max_output_length since the KV/buffer memory the probe
-# sizes against scales with it (state_capacity = padded_length + max_output_length + 1).
+# Auto-batch probe results {(id(model), vram, max_output_length): {padded_length: batch_size}}: lets a
+# resident server skip the throwaway probe compiles. Keyed on max_output_length since state_capacity scales with it.
 _PROBE_CACHE: dict[tuple[int, int, int], dict[int, int]] = {}
+
+
+def clear_probe_cache() -> None:
+    _PROBE_CACHE.clear()
 
 
 @dataclass(frozen=True)
@@ -226,7 +228,7 @@ def bucket_sequences[T: TokenSequence](
     max_vram: int,
     starting_batch_size: int = 2,
     min_batches_per_bucket: int = MIN_BATCHES_PER_BUCKET,
-    probe_cache: dict[int, int] | None = None,
+    probe_cache: dict[int, int],
 ) -> tuple[dict[int, list[tuple[int, T]]], dict[int, int]]:
     sequences_per_bucket = bucket_by_length(tokenized)
     sorted_lengths = sorted(sequences_per_bucket.keys(), reverse=True)
@@ -235,10 +237,8 @@ def bucket_sequences[T: TokenSequence](
     num_steps = 3
 
     for idx, padded_length in enumerate(sorted_lengths):
-        # Reuse a previously measured batch size for this padded_length when available.
-        # The auto-batch probe runs throwaway compile+forward passes that dominate per-request
-        # latency on a resident server; the result only depends on (model, padded_length, vram).
-        if probe_cache is not None and padded_length in probe_cache:
+        # Reuse a cached batch size for this padded_length (the probe's throwaway compiles dominate latency).
+        if padded_length in probe_cache:
             estimated = probe_cache[padded_length]
         else:
             estimated = estimate_batchsize_for_memory_budget(
@@ -247,8 +247,7 @@ def bucket_sequences[T: TokenSequence](
                 starting_batchsize=estimated,
                 num_steps=num_steps,
             )
-            if probe_cache is not None:
-                probe_cache[padded_length] = estimated
+            probe_cache[padded_length] = estimated
 
         # 1 estimator step suffices for each consecutive estimation, since we will already have
         # ~80% VRAM allocation ratio by starting from the last batchsize estimate, and 1 step is enough

--- a/lalamo/inference/batch_scheduler.py
+++ b/lalamo/inference/batch_scheduler.py
@@ -41,6 +41,11 @@ PROMPT_SIZE_BUCKETS: tuple[int, ...] = tuple(256 * 4**i for i in range(8))
 MIN_BATCHES_PER_BUCKET: int = 10
 MAX_BOUNDARY_BATCH_PADDING_FRACTION: float = 0.05
 
+# Cache of auto-batch probe results, keyed by (id(model), vram_bytes) -> {padded_length: batch_size}.
+# Lets a resident server skip re-running the expensive probe (throwaway compiles + forwards) for
+# shapes it has already measured. Keyed on model identity so a different/reloaded model re-probes.
+_PROBE_CACHE: dict[tuple[int, int], dict[int, int]] = {}
+
 
 @dataclass(frozen=True)
 class BatchSchedulerConfig:
@@ -219,6 +224,7 @@ def bucket_sequences[T: TokenSequence](
     max_vram: int,
     starting_batch_size: int = 2,
     min_batches_per_bucket: int = MIN_BATCHES_PER_BUCKET,
+    probe_cache: dict[int, int] | None = None,
 ) -> tuple[dict[int, list[tuple[int, T]]], dict[int, int]]:
     sequences_per_bucket = bucket_by_length(tokenized)
     sorted_lengths = sorted(sequences_per_bucket.keys(), reverse=True)
@@ -227,12 +233,20 @@ def bucket_sequences[T: TokenSequence](
     num_steps = 3
 
     for idx, padded_length in enumerate(sorted_lengths):
-        estimated = estimate_batchsize_for_memory_budget(
-            functools.partial(memory_probe, padded_length=padded_length),
-            memory_budget=max_vram,
-            starting_batchsize=estimated,
-            num_steps=num_steps,
-        )
+        # Reuse a previously measured batch size for this padded_length when available.
+        # The auto-batch probe runs throwaway compile+forward passes that dominate per-request
+        # latency on a resident server; the result only depends on (model, padded_length, vram).
+        if probe_cache is not None and padded_length in probe_cache:
+            estimated = probe_cache[padded_length]
+        else:
+            estimated = estimate_batchsize_for_memory_budget(
+                functools.partial(memory_probe, padded_length=padded_length),
+                memory_budget=max_vram,
+                starting_batchsize=estimated,
+                num_steps=num_steps,
+            )
+            if probe_cache is not None:
+                probe_cache[padded_length] = estimated
 
         # 1 estimator step suffices for each consecutive estimation, since we will already have
         # ~80% VRAM allocation ratio by starting from the last batchsize estimate, and 1 step is enough
@@ -805,11 +819,14 @@ class BatchScheduler(ABC):
                 if first_result is not None:
                     jax.block_until_ready(first_result)
 
+            max_vram = _memory_budget_for_auto_batching(vram_bytes)
+            probe_cache = _PROBE_CACHE.setdefault((id(self.model), max_vram), {})
             sequences_per_bucket, batch_size_per_bucket = bucket_sequences(
                 tokenized,
                 memory_probe,
-                max_vram=_memory_budget_for_auto_batching(vram_bytes),
+                max_vram=max_vram,
                 min_batches_per_bucket=MIN_BATCHES_PER_BUCKET,
+                probe_cache=probe_cache,
             )
 
         buckets = merge_small_buckets(sequences_per_bucket, batch_size_per_bucket, min_batches=MIN_BATCHES_PER_BUCKET)

--- a/lalamo/server.py
+++ b/lalamo/server.py
@@ -103,8 +103,7 @@ _model_cache: dict[tuple[str, str | None], LanguageModel] = {}
 
 def _load_resident_model(model_path: str, dtype: str | None) -> LanguageModel:
     cache_key = (model_path, dtype)
-    cached = _model_cache.get(cache_key)
-    if cached is not None:
+    if (cached := _model_cache.get(cache_key)) is not None:
         return cached
 
     # Free the old model's device buffers before importing the new one (avoid two full models in VRAM).
@@ -116,10 +115,10 @@ def _load_resident_model(model_path: str, dtype: str | None) -> LanguageModel:
     model = import_model(
         model_path,
         sharding_config=ShardingConfig.replicated(),
-        dtype=jnp.dtype(dtype),
+        dtype=jnp.dtype(dtype) if dtype is not None else None,
     ).model
     if not isinstance(model, LanguageModel):
-        raise RuntimeError(f"Expected a language model, got {type(model).__name__}")  # noqa: TRY004
+        raise TypeError(f"Expected a language model, got {type(model).__name__}")
 
     _model_cache[cache_key] = model
     return model

--- a/lalamo/server.py
+++ b/lalamo/server.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse
 from jax import numpy as jnp
 
 from lalamo.data.huggingface_message import HFMessage
-from lalamo.inference.batch_scheduler import BatchSchedulerConfig, ContinuousBatchScheduler
+from lalamo.inference.batch_scheduler import BatchSchedulerConfig, ContinuousBatchScheduler, clear_probe_cache
 from lalamo.model_import.common import import_model
 from lalamo.models import GenerationConfig, LanguageModel
 from lalamo.module import Keychain
@@ -97,24 +97,20 @@ class Batch:
 gpu_lock = asyncio.Lock()
 creation_lock = asyncio.Lock()
 
-# Keep the imported+loaded model resident across /batches requests so that
-# import_model (the full safetensors reload) and the warm eqx.filter_jit caches
-# are paid once instead of per request. Keyed on the parameters that change the
-# loaded weights/structure; a different model/dtype reloads.
-_model_cache: dict[tuple[str, str], LanguageModel] = {}
+# Resident model across /batches requests: pay the safetensors reload + jit warmup once, not per request.
+_model_cache: dict[tuple[str, str | None], LanguageModel] = {}
 
 
 def _load_resident_model(model_path: str, dtype: str | None) -> LanguageModel:
-    cache_key = (model_path, str(dtype))
+    cache_key = (model_path, dtype)
     cached = _model_cache.get(cache_key)
     if cached is not None:
         return cached
 
-    # A different model/dtype: drop the previously resident model and free its
-    # device buffers before loading the new one, so multiple full models don't
-    # accumulate in VRAM (preserves the prior one-model-at-a-time footprint).
+    # Free the old model's device buffers before importing the new one (avoid two full models in VRAM).
     if _model_cache:
         _model_cache.clear()
+        clear_probe_cache()  # its entries are id(model)-keyed and must not outlive this model
         gc.collect()
 
     model = import_model(

--- a/lalamo/server.py
+++ b/lalamo/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import json
 import os
 import random
@@ -108,6 +109,13 @@ def _load_resident_model(model_path: str, dtype: str | None) -> LanguageModel:
     cached = _model_cache.get(cache_key)
     if cached is not None:
         return cached
+
+    # A different model/dtype: drop the previously resident model and free its
+    # device buffers before loading the new one, so multiple full models don't
+    # accumulate in VRAM (preserves the prior one-model-at-a-time footprint).
+    if _model_cache:
+        _model_cache.clear()
+        gc.collect()
 
     model = import_model(
         model_path,

--- a/lalamo/server.py
+++ b/lalamo/server.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse
 from jax import numpy as jnp
 
 from lalamo.data.huggingface_message import HFMessage
-from lalamo.inference.batch_scheduler import BatchSchedulerConfig, ContinuousBatchScheduler, clear_probe_cache
+from lalamo.inference.batch_scheduler import _PROBE_CACHE, BatchSchedulerConfig, ContinuousBatchScheduler
 from lalamo.model_import.common import import_model
 from lalamo.models import GenerationConfig, LanguageModel
 from lalamo.module import Keychain
@@ -97,19 +97,24 @@ class Batch:
 gpu_lock = asyncio.Lock()
 creation_lock = asyncio.Lock()
 
+
 # Resident model across /batches requests: pay the safetensors reload + jit warmup once, not per request.
-_model_cache: dict[tuple[str, str | None], LanguageModel] = {}
+_resident_model: tuple[tuple[str, str | None], LanguageModel] | None = None
 
 
 def _load_resident_model(model_path: str, dtype: str | None) -> LanguageModel:
-    cache_key = (model_path, dtype)
-    if (cached := _model_cache.get(cache_key)) is not None:
-        return cached
+    global _resident_model  # noqa: PLW0603
 
-    # Free the old model's device buffers before importing the new one (avoid two full models in VRAM).
-    if _model_cache:
-        _model_cache.clear()
-        clear_probe_cache()  # its entries are id(model)-keyed and must not outlive this model
+    cache_key = (model_path, dtype)
+    if _resident_model is not None:
+        cached_key, cached_model = _resident_model
+        if cached_key == cache_key:
+            return cached_model
+
+        # Free the old model's device buffers before importing the new one (avoid two full models in VRAM).
+        _resident_model = None
+        del cached_model
+        _PROBE_CACHE.clear()  # its entries are id(model)-keyed and must not outlive this model
         gc.collect()
 
     model = import_model(
@@ -120,7 +125,7 @@ def _load_resident_model(model_path: str, dtype: str | None) -> LanguageModel:
     if not isinstance(model, LanguageModel):
         raise TypeError(f"Expected a language model, got {type(model).__name__}")
 
-    _model_cache[cache_key] = model
+    _resident_model = (cache_key, model)
     return model
 
 

--- a/lalamo/server.py
+++ b/lalamo/server.py
@@ -96,6 +96,30 @@ class Batch:
 gpu_lock = asyncio.Lock()
 creation_lock = asyncio.Lock()
 
+# Keep the imported+loaded model resident across /batches requests so that
+# import_model (the full safetensors reload) and the warm eqx.filter_jit caches
+# are paid once instead of per request. Keyed on the parameters that change the
+# loaded weights/structure; a different model/dtype reloads.
+_model_cache: dict[tuple[str, str], LanguageModel] = {}
+
+
+def _load_resident_model(model_path: str, dtype: str | None) -> LanguageModel:
+    cache_key = (model_path, str(dtype))
+    cached = _model_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    model = import_model(
+        model_path,
+        sharding_config=ShardingConfig.replicated(),
+        dtype=jnp.dtype(dtype),
+    ).model
+    if not isinstance(model, LanguageModel):
+        raise RuntimeError(f"Expected a language model, got {type(model).__name__}")  # noqa: TRY004
+
+    _model_cache[cache_key] = model
+    return model
+
 
 def active_batch_ids() -> set[str]:
     if not hasattr(app.state, "active_batch_ids"):
@@ -159,13 +183,7 @@ def validate_requests(
 def generate_replies(requests: list[RequestBody]) -> Iterator[ResponseBody]:
     reference, *_ = requests
 
-    model = import_model(
-        reference.model,
-        sharding_config=ShardingConfig.replicated(),
-        dtype=jnp.dtype(reference.dtype),
-    ).model
-    if not isinstance(model, LanguageModel):
-        raise RuntimeError(f"Expected a language model, got {type(model).__name__}")  # noqa: TRY004
+    model = _load_resident_model(reference.model, reference.dtype)
 
     dataset = [[hf_message.as_message() for hf_message in request.messages] for request in requests]
 


### PR DESCRIPTION
## What

The `/batches` server path re-did its entire cold start on **every request**:

1. `generate_replies` called `import_model(...)` each time — a full safetensors reload of the model.
2. The auto-batch sizer re-ran its memory probe each time — throwaway compiles + forward passes at growing batch sizes, just to estimate the batch size.

On a long-lived server these dominate per-request latency, even though both results are identical across requests for the same model.

This PR makes both resident:

- **`server.py`** — `_load_resident_model` caches the imported+loaded model keyed by `(model, dtype)`. The reload and the warm `eqx.filter_jit` caches are paid once; a different model/dtype reloads.
- **`batch_scheduler.py`** — a module-level `_PROBE_CACHE` keyed by `(id(model), vram_bytes)` memoizes the auto-batch result per `padded_length`. `bucket_sequences` takes an optional `probe_cache` and skips `estimate_batchsize_for_memory_budget` for shapes already measured; `reply_many` wires in the per-model cache. A reloaded model gets a fresh entry (its `id` changes).

## Effect

On a resident server, a warm 8-request `/batches` call drops from **~189s → ~6s (~340 tok/s)** — i.e. server overhead is removed and it runs at the in-process engine's speed.

## Correctness

Pure memoization; no change to generation. Greedy output is byte-identical before/after across cold/warm and multiple batch sizes. The probe cache is keyed on model identity, so a different/reloaded model re-probes.
