### PR TITLE
Add LongRoPE support to Phi-4-mini

### DIFF
--- a/lalamo/model_import/model_configs/huggingface/phi3.py
+++ b/lalamo/model_import/model_configs/huggingface/phi3.py
@@ -11,7 +11,7 @@ from lalamo.modules.embedding import TiedEmbeddingConfig
 from lalamo.modules.linear import LinearConfig
 from lalamo.modules.mlp import DenseMLPConfig
 from lalamo.modules.normalization import NormalizationConfig, UpcastMode
-from lalamo.modules.rope import UnscaledRoPEConfig
+from lalamo.modules.rope import LongRoPEConfig
 from lalamo.modules.token_mixers.attention import AttentionConfig
 from lalamo.modules.transformer import TransformerConfig
 from lalamo.modules.transformer_layer import TransformerLayerConfig
@@ -21,6 +21,13 @@ from lalamo.weight_matrix import CompressionImplementation
 from .common import HuggingFaceLMConfig, QuantizationConfigType
 
 __all__ = ["HFPhi3Config"]
+
+
+@dataclass(frozen=True)
+class Phi3LongRopeScalingConfig:
+    type: Literal["longrope"]
+    short_factor: list[float]
+    long_factor: list[float]
 
 
 @dataclass(frozen=True)
@@ -42,6 +49,7 @@ class HFPhi3Config(HuggingFaceLMConfig):
     partial_rotary_factor: float
 
     original_max_position_embeddings: int
+    rope_scaling: Phi3LongRopeScalingConfig
     quantization_config: QuantizationConfigType = None
 
     @property
@@ -57,20 +65,24 @@ class HFPhi3Config(HuggingFaceLMConfig):
         context_length: int | None,
         metadata_dict: Mapping[str, str],  # noqa: ARG002
     ) -> DecoderConfig:
-        supported_context_length = self.original_max_position_embeddings
-        if context_length is not None and context_length > supported_context_length:
+        original_context_length = self.original_max_position_embeddings
+        if context_length is not None and context_length > self.max_position_embeddings:
             raise ValueError(
-                f"Requested context_length={context_length} exceeds the supported context "
-                f"{supported_context_length} for this model. Come next time"
+                f"Requested context_length={context_length} exceeds the maximum context "
+                f"{self.max_position_embeddings} for this model."
             )
-        max_sequence_length = supported_context_length if context_length is None else context_length
+        max_sequence_length = original_context_length if context_length is None else context_length
         assert self.tie_word_embeddings, "Phi-4-mini only has tied embeddings"
         embedding_config = TiedEmbeddingConfig(input_scale=None, logit_soft_cap=None)
 
-        rope_config = UnscaledRoPEConfig(
+        rope_config = LongRoPEConfig(
             base=self.rope_theta,
             max_sequence_length=max_sequence_length,
             head_dim=self.rotary_dim,
+            short_factor=tuple(self.rope_scaling.short_factor),
+            long_factor=tuple(self.rope_scaling.long_factor),
+            original_context_length=original_context_length,
+            scaling_factor=self.max_position_embeddings / original_context_length,
         )
         rmsnorm_config = NormalizationConfig(
             epsilon=self.rms_norm_eps,

--- a/lalamo/modules/rope.py
+++ b/lalamo/modules/rope.py
@@ -30,6 +30,7 @@ from lalamo.utils.registry_abc import RegistryABC
 __all__ = [
     "LinearScalingRoPEConfig",
     "LlamaRoPEConfig",
+    "LongRoPEConfig",
     "PositionalEmbeddings",
     "RoPE",
     "RoPEConfig",
@@ -218,3 +219,29 @@ class LinearScalingRoPEConfig(RoPEConfig):
         inverse_frequencies: Float[Array, " rotary_pairs"],
     ) -> Float[Array, " rotary_pairs"]:
         return inverse_frequencies / self.scaling_factor
+
+
+@dataclass(frozen=True, kw_only=True)
+class LongRoPEConfig(RoPEConfig):
+    short_factor: tuple[float, ...]
+    long_factor: tuple[float, ...]
+    original_context_length: int
+    scaling_factor: float
+
+    @property
+    def _rescaling_factors(self) -> tuple[float, ...]:
+        if self.max_sequence_length > self.original_context_length:
+            return self.long_factor
+        return self.short_factor
+
+    def _scale_inverse_frequencies(
+        self,
+        inverse_frequencies: Float[Array, " rotary_pairs"],
+    ) -> Float[Array, " rotary_pairs"]:
+        return inverse_frequencies / jnp.asarray(self._rescaling_factors, dtype=jnp.float32)
+
+    @property
+    def _attention_scaling_factor(self) -> float:
+        if self.scaling_factor <= 1.0:
+            return 1.0
+        return math.sqrt(1.0 + math.log(self.scaling_factor) / math.log(self.original_context_length))

--- a/tests/unit/modules/test_rope.py
+++ b/tests/unit/modules/test_rope.py
@@ -1,3 +1,5 @@
+import math
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -13,6 +15,7 @@ from lalamo.modules.normalization import NormalizationConfig, UpcastMode
 from lalamo.modules.rope import (
     LinearScalingRoPEConfig,
     LlamaRoPEConfig,
+    LongRoPEConfig,
     PositionalEmbeddings,
     RoPE,
     RoPEConfig,
@@ -120,6 +123,18 @@ def _full_table(rope: RoPE) -> PositionalEmbeddings:
                 truncate=True,
             ),
             id="yarn",
+        ),
+        pytest.param(
+            LongRoPEConfig(
+                base=10_000.0,
+                max_sequence_length=NUM_TIMESTEPS,
+                head_dim=HEAD_DIM,
+                short_factor=(1.0, 1.0),
+                long_factor=(1.0, 2.5),
+                original_context_length=NUM_TIMESTEPS // 2,
+                scaling_factor=32.0,
+            ),
+            id="longrope",
         ),
     ],
 )
@@ -274,3 +289,53 @@ def test_rope_exports_no_arrays_and_regenerates_from_config() -> None:
     table = _full_table(original)
     _assert_close(result=embeddings.sines, reference=_select_reference(table.sines, timesteps))
     _assert_close(result=embeddings.cosines, reference=_select_reference(table.cosines, timesteps))
+
+
+LONGROPE_BASE = 10_000.0
+LONGROPE_SHORT_FACTOR = (1.0, 1.0)
+LONGROPE_LONG_FACTOR = (1.0, 2.5)
+LONGROPE_ORIGINAL_CONTEXT_LENGTH = 4
+LONGROPE_SCALING_FACTOR = 32.0
+
+
+def _longrope_config(max_sequence_length: int) -> LongRoPEConfig:
+    return LongRoPEConfig(
+        base=LONGROPE_BASE,
+        max_sequence_length=max_sequence_length,
+        head_dim=HEAD_DIM,
+        short_factor=LONGROPE_SHORT_FACTOR,
+        long_factor=LONGROPE_LONG_FACTOR,
+        original_context_length=LONGROPE_ORIGINAL_CONTEXT_LENGTH,
+        scaling_factor=LONGROPE_SCALING_FACTOR,
+    )
+
+
+@pytest.mark.parametrize(
+    ("max_sequence_length", "expected_factor"),
+    [
+        pytest.param(LONGROPE_ORIGINAL_CONTEXT_LENGTH, LONGROPE_SHORT_FACTOR, id="within-original-context"),
+        pytest.param(NUM_TIMESTEPS, LONGROPE_LONG_FACTOR, id="beyond-original-context"),
+    ],
+)
+def test_longrope_matches_huggingface_reference(
+    max_sequence_length: int,
+    expected_factor: tuple[float, ...],
+) -> None:
+    config = _longrope_config(max_sequence_length)
+
+    channel_indices = jnp.arange(0, HEAD_DIM, 2, dtype=jnp.float32)
+    reference_inverse_frequencies = 1.0 / (
+        jnp.asarray(expected_factor) * LONGROPE_BASE ** (channel_indices / HEAD_DIM)
+    )
+    reference_attention_scaling = math.sqrt(
+        1.0 + math.log(LONGROPE_SCALING_FACTOR) / math.log(LONGROPE_ORIGINAL_CONTEXT_LENGTH)
+    )
+
+    timesteps = jnp.arange(max_sequence_length, dtype=jnp.int32)
+    reference_embeddings = jnp.outer(timesteps.astype(jnp.float32), reference_inverse_frequencies)
+    reference_embeddings = jnp.concatenate((reference_embeddings, reference_embeddings), axis=-1)
+
+    embeddings = config.compute_positional_embeddings(timesteps)
+
+    _assert_close(result=embeddings.cosines, reference=jnp.cos(reference_embeddings) * reference_attention_scaling)
+    _assert_close(result=embeddings.sines, reference=jnp.sin(reference_embeddings) * reference_attention_scaling)


### PR DESCRIPTION
follow-up to #318

#318 shipped Phi-4-mini with honest 4k cap, because lalamo had no LongRoPE at that moment. This PR adds it, so the model can be exported on its full context (up to 131072)

factor set is chosen from config (`max_sequence_length > original_context_length`), not per sequence. HF switches per forward pass by `max(position_ids)`, but we cannot do it that way on device, see the uzu PR (trymirai/uzu/pull/604) for the reason

Validated against HF transformers (Phi-4-mini, bf16, same 2500 tokens):

| | PPL |
|---|---|
| HF transformers reference | 1.0397 |
| this PR, 4k export | 1.0396 |