### PR TITLE
Make SiLU implementation numerically stable.

### DIFF
--- a/lalamo/modules/activations.py
+++ b/lalamo/modules/activations.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from dataclasses import dataclass
 
 import jax
-import jax.numpy as jnp
 from jaxtyping import Array, Float
 
 from lalamo.module import LalamoConfig
@@ -27,7 +26,7 @@ class SiLU(Activation):
     alpha: float = 1.0
 
     def __call__(self, x: Float[Array, "..."]) -> Float[Array, "..."]:
-        return x / (1 + jnp.exp(-x * self.alpha))
+        return x * jax.nn.sigmoid(self.alpha * x)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The current implementation will produce NaN gradients during the backward pass for large input values even though the value itself is finite. jax.nn.sigmoid is a numerically stable alternative.