### PR TITLE
Enable native MXFP4 inference for GPT-OSS

### DIFF
--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 from einops import rearrange
 from jaxtyping import Array
 
-from lalamo.compressed import IntMatrix, IntSpec, MLXMatrix, MLXSpec
+from lalamo.compressed import IntMatrix, IntSpec, MicrofloatSpec, MLXMatrix, MLXSpec
 from lalamo.compressed.utils.packing import pack_uint_to_uint8
 from lalamo.modules.classifier import Classifier
 from lalamo.modules.decoder import Decoder
@@ -28,7 +28,6 @@ from lalamo.utils.surgery import load_as_at
 from lalamo.weight_matrix import CompressionImplementation, EmbeddingMatrix, Layout, WeightMatrix
 
 from .common import load_full_precision
-from .utils import decode_mxfp4, deinterleave_pairwise_columns
 
 __all__ = ["load_huggingface_decoder", "load_linear", "load_rmsnorm"]
 
@@ -38,6 +37,60 @@ AWQ_UINT4_REVERSE_ORDER = jnp.array([0, 4, 1, 5, 2, 6, 3, 7], dtype=jnp.int32)
 
 def _update_linear(module: Linear, weights: WeightMatrix, biases: Array | None) -> Linear:
     return eqx.tree_at(lambda m: (m.weights, m.biases), module, (weights, biases))
+
+
+def _load_mxfp4_matrix(
+    template: WeightMatrix,
+    blocks: Array,
+    scales: Array,
+    *,
+    group_size: int = 32,
+    implementation: CompressionImplementation,
+) -> WeightMatrix:
+    """Packed MXFP4 blocks with raw E8M0 scale bytes."""
+    if blocks.dtype != jnp.dtype(jnp.uint8):
+        raise ValueError(f"MXFP4 blocks must be U8, got {blocks.dtype}")
+    if blocks.ndim != scales.ndim + 1 or blocks.shape[:-1] != scales.shape:
+        raise ValueError(f"MXFP4 block/scale shape mismatch: blocks={blocks.shape}, scales={scales.shape}")
+    if blocks.shape[-1] * 2 != group_size:
+        raise ValueError(f"MXFP4 group size {group_size} does not match {blocks.shape[-1]} packed bytes")
+
+    if scales.dtype == jnp.dtype(jnp.float8_e8m0fnu):
+        packed_scales = jax.lax.bitcast_convert_type(scales, jnp.uint8)
+    elif scales.dtype == jnp.dtype(jnp.uint8):
+        packed_scales = scales
+    else:
+        raise ValueError(f"MXFP4 scales must be F8_E8M0 or U8, got {scales.dtype}")
+
+    packed_weights = rearrange(blocks, "... rows groups packed -> ... rows (groups packed)")
+    global_scale = jnp.ones(blocks.shape[:-3], dtype=template.dtype)
+    return MicrofloatSpec(group_size=group_size).from_packed_parameters(
+        packed_weights=packed_weights,
+        packed_scales=packed_scales,
+        global_scale=global_scale,
+        dtype=template.dtype,
+        implementation=implementation,
+        sharding_config=template.sharding_config,
+        is_sharded=template.is_sharded,
+    )
+
+
+def _stack_gpt_oss_gate_up(blocks: Array, scales: Array) -> tuple[Array, Array]:
+    """Canonical up/gate rows with 16-value groups, without decoding MXFP4."""
+    up_blocks = blocks[..., 1::2, :, :]
+    gate_blocks = blocks[..., 0::2, :, :]
+    blocks = jnp.concatenate((up_blocks, gate_blocks), axis=-3)
+    blocks = rearrange(
+        blocks,
+        "... rows groups (halves packed) -> ... rows (groups halves) packed",
+        halves=2,
+    )
+
+    up_scales = scales[..., 1::2, :]
+    gate_scales = scales[..., 0::2, :]
+    scales = jnp.concatenate((up_scales, gate_scales), axis=-2)
+    scales = jnp.repeat(scales, 2, axis=-1)
+    return blocks, scales
 
 
 def _dense_mlp_projections(module: DenseMLP) -> tuple[Linear, Linear]:
@@ -435,57 +488,49 @@ def load_moe(
     down_path = experts_path / "down_proj"
     batched_gate_up_path = _first_path(weights_dict, (gate_up_path, gate_up_path / "weight"))
 
-    # GPT-OSS uses fused MXFP4 expert weights; detect and decode those.
+    # Preserve MXFP4 while restoring Lalamo's canonical [all up, all gate] rows.
     if (experts_path / "gate_up_proj_blocks") in weights_dict:
-        fused = decode_mxfp4(
-            weights_dict[experts_path / "gate_up_proj_blocks"],
-            weights_dict[experts_path / "gate_up_proj_scales"],
-            dtype=module.experts.up_projection.weights.dtype,
-            flatten=False,
-        )
-        fused_eio = rearrange(fused, "e o ib ie -> e (ib ie) o")
-        up_weights, gate_weights = deinterleave_pairwise_columns(fused_eio, first="odd")
-        combined_up_gate_weights = jnp.swapaxes(
-            jnp.concatenate([up_weights, gate_weights], axis=-1),
-            -1,
-            -2,
+        gate_up_blocks = weights_dict[experts_path / "gate_up_proj_blocks"]
+        gate_up_scales = weights_dict[experts_path / "gate_up_proj_scales"]
+        gate_up_blocks, gate_up_scales = _stack_gpt_oss_gate_up(gate_up_blocks, gate_up_scales)
+        gate_up_weights = _load_mxfp4_matrix(
+            module.experts.up_projection.weights,
+            gate_up_blocks,
+            gate_up_scales,
+            group_size=16,
+            implementation=implementation,
         )
 
         gate_up_bias = weights_dict[experts_path / "gate_up_proj_bias"]
         if gate_up_bias.ndim == 1:
             gate_up_bias = jnp.broadcast_to(
                 gate_up_bias,
-                (combined_up_gate_weights.shape[0], gate_up_bias.shape[0]),
+                (gate_up_blocks.shape[0], gate_up_bias.shape[0]),
             )
-        up_bias, gate_bias = deinterleave_pairwise_columns(gate_up_bias, first="odd")
-        combined_up_gate_biases = jnp.concatenate([up_bias + 1.0, gate_bias], axis=-1)
+        up_bias = gate_up_bias[..., 1::2] + jnp.asarray(1.0, dtype=gate_up_bias.dtype)
+        gate_bias = gate_up_bias[..., 0::2]
+        gate_up_bias = jnp.concatenate((up_bias, gate_bias), axis=-1)
 
         up_projection = _update_linear(
             module.experts.up_projection,
-            load_full_precision(
-                module.experts.up_projection.weights,
-                combined_up_gate_weights,
-            ),
-            combined_up_gate_biases,
+            gate_up_weights,
+            gate_up_bias,
         )
 
-        down_weights = decode_mxfp4(
-            weights_dict[experts_path / "down_proj_blocks"],
+        down_blocks = weights_dict[experts_path / "down_proj_blocks"]
+        down_weights = _load_mxfp4_matrix(
+            module.experts.down_projection.weights,
+            down_blocks,
             weights_dict[experts_path / "down_proj_scales"],
-            dtype=module.experts.down_projection.weights.dtype,
-            flatten=False,
+            implementation=implementation,
         )
-        down_weights = rearrange(down_weights, "e o ib ie -> e o (ib ie)")
         down_biases = weights_dict[experts_path / "down_proj_bias"]
         if down_biases.ndim == 1:
-            down_biases = jnp.broadcast_to(down_biases, (*down_weights.shape[:-1], down_biases.shape[0]))
+            down_biases = jnp.broadcast_to(down_biases, (down_blocks.shape[0], down_biases.shape[0]))
 
         down_projection = _update_linear(
             module.experts.down_projection,
-            load_full_precision(
-                module.experts.down_projection.weights,
-                down_weights,
-            ),
+            down_weights,
             down_biases,
         )
 

--- a/tests/unit/test_model_import_loading.py
+++ b/tests/unit/test_model_import_loading.py
@@ -4,6 +4,7 @@ from math import prod
 from pathlib import Path
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -12,6 +13,7 @@ from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 
 from lalamo.compressed.int import IntMatrixForInference, IntMatrixForTraining, IntSpec
+from lalamo.compressed.microfloat import MicrofloatMatrixForInference
 from lalamo.compressed.mlx import MLXMatrixForInference, MLXMatrixForTraining
 from lalamo.initializer import EmptyInitializer, Initializer
 from lalamo.model import Model, ModelConfig
@@ -19,16 +21,25 @@ from lalamo.model_import.loaders.huggingface import (
     load_huggingface_classifier,
     load_input_embedding_matrix,
     load_linear,
+    load_moe,
 )
+from lalamo.model_import.loaders.utils import decode_mxfp4
 from lalamo.model_import.model_configs.foreign_config import ForeignConfig
 from lalamo.model_import.model_configs.huggingface import ModernBERTConfig
 from lalamo.models.chat_codec import ChatCodec, ChatCodecConfig
 from lalamo.module import Keychain, LalamoConfig, LalamoModule
+from lalamo.modules.activations import SiLU
 from lalamo.modules.classifier import Classifier
 from lalamo.modules.decoder import PerLayerEmbedding, PLEModelConfig
 from lalamo.modules.embedding import TiedEmbedding
 from lalamo.modules.linear import Linear, LinearConfig
-from lalamo.modules.mlp import DenseMLP
+from lalamo.modules.mlp import (
+    DenseMLP,
+    DenseMLPConfig,
+    MixtureOfExperts,
+    MixtureOfExpertsConfig,
+    SoftmaxRouting,
+)
 from lalamo.modules.normalization import NormalizationConfig, UpcastMode
 from lalamo.modules.token_mixers.attention import Attention
 from lalamo.utils.dummy_array import dummy_array
@@ -79,6 +90,30 @@ def _linear_template(dtype: DTypeLike | None, layout: Layout = Layout.OUTPUT_INP
         sharding_config=make_test_sharding_config(),
     )
     return eqx.tree_at(lambda module: module.weights, result, weights)
+
+
+def _gpt_oss_moe_template() -> MixtureOfExperts:
+    linear_config = LinearConfig()
+    expert_config = DenseMLPConfig(
+        linear_config=linear_config,
+        activation=SiLU(alpha=1.702),
+        has_up_biases=True,
+        has_down_biases=True,
+        gate_clipping=(None, 7.0),
+        up_clipping=(-6.0, 8.0),
+    )
+    config = MixtureOfExpertsConfig(
+        expert_config=expert_config,
+        router_config=linear_config,
+        routing_function=SoftmaxRouting(),
+        num_routed_experts=2,
+        num_active_routed_experts=1,
+        router_has_biases=True,
+        num_shared_experts=0,
+        expert_hidden_dim=32,
+    )
+    initializer = EmptyInitializer(default_dtype=jnp.bfloat16, sharding_config=make_test_sharding_config())
+    return config.init(initializer, model_dim=64, hidden_dim=64)
 
 
 def _mlx_weights(path: ParameterPath) -> Mapping[str, Array]:
@@ -322,6 +357,74 @@ def test_load_linear_full_precision_strong_template_forces_template_dtype() -> N
 
     assert isinstance(loaded.weights, FullPrecisionMatrix)
     assert loaded.weights.dtype == jnp.float32
+
+
+def test_load_gpt_oss_moe_preserves_native_mxfp4_payload_and_canonical_rows() -> None:
+    module = _gpt_oss_moe_template()
+    path = ParameterPath()
+    experts_path = path / "experts"
+    gate_up_blocks = jnp.arange(2 * 64 * 2 * 16, dtype=jnp.int32).astype(jnp.uint8).reshape(2, 64, 2, 16)
+    gate_up_scale_bytes = ((jnp.arange(2 * 64 * 2, dtype=jnp.int32) % 5) + 125).astype(jnp.uint8)
+    gate_up_scale_bytes = gate_up_scale_bytes.reshape(2, 64, 2)
+    gate_up_scales = jax.lax.bitcast_convert_type(gate_up_scale_bytes, jnp.float8_e8m0fnu)
+    down_blocks = jnp.arange(2 * 64 * 16, dtype=jnp.int32).astype(jnp.uint8).reshape(2, 64, 1, 16)
+    down_scale_bytes = ((jnp.arange(2 * 64, dtype=jnp.int32) % 3) + 126).astype(jnp.uint8)
+    down_scale_bytes = down_scale_bytes.reshape(2, 64, 1)
+    down_scales = jax.lax.bitcast_convert_type(down_scale_bytes, jnp.float8_e8m0fnu)
+    gate_up_bias = jnp.arange(64, dtype=jnp.bfloat16)
+    down_bias = jnp.arange(64, dtype=jnp.bfloat16)
+    weights: Mapping[str, Array] = {
+        path / "router" / "weight": jnp.zeros((2, 64), dtype=jnp.bfloat16),
+        path / "router" / "bias": jnp.zeros((2,), dtype=jnp.bfloat16),
+        experts_path / "gate_up_proj_blocks": gate_up_blocks,
+        experts_path / "gate_up_proj_scales": gate_up_scales,
+        experts_path / "gate_up_proj_bias": gate_up_bias,
+        experts_path / "down_proj_blocks": down_blocks,
+        experts_path / "down_proj_scales": down_scales,
+        experts_path / "down_proj_bias": down_bias,
+    }
+
+    loaded = load_moe(module, weights, path)
+
+    up_weights = loaded.experts.up_projection.weights
+    down_weights = loaded.experts.down_projection.weights
+    assert isinstance(up_weights, MicrofloatMatrixForInference)
+    assert isinstance(down_weights, MicrofloatMatrixForInference)
+    expected_up_blocks = jnp.concatenate((gate_up_blocks[:, 1::2], gate_up_blocks[:, 0::2]), axis=1)
+    expected_up_blocks = expected_up_blocks.reshape(2, 64, 2, 2, 8).reshape(2, 64, 32)
+    expected_up_scales = jnp.concatenate((gate_up_scale_bytes[:, 1::2], gate_up_scale_bytes[:, 0::2]), axis=1)
+    expected_up_scales = jnp.repeat(expected_up_scales, 2, axis=-1)
+    assert up_weights.spec.group_size == 16
+    assert jnp.array_equal(up_weights.packed_weights, expected_up_blocks)
+    assert jnp.array_equal(up_weights.packed_scales, expected_up_scales)
+    assert down_weights.spec.group_size == 32
+    assert jnp.array_equal(down_weights.packed_weights, down_blocks.reshape(2, 64, 16))
+    assert jnp.array_equal(down_weights.packed_scales, down_scale_bytes)
+
+    expected_up_weights = decode_mxfp4(
+        gate_up_blocks,
+        gate_up_scale_bytes,
+        dtype=up_weights.dtype,
+        flatten=False,
+    )
+    expected_up_weights = jnp.concatenate((expected_up_weights[:, 1::2], expected_up_weights[:, 0::2]), axis=1)
+    expected_up_weights = expected_up_weights.reshape(2, 64, 64)
+    expected_down_weights = decode_mxfp4(
+        down_blocks,
+        down_scale_bytes,
+        dtype=down_weights.dtype,
+        flatten=False,
+    ).reshape(2, 64, 32)
+    np.testing.assert_array_equal(up_weights.decompress(), expected_up_weights)
+    np.testing.assert_array_equal(down_weights.decompress(), expected_down_weights)
+
+    assert loaded.experts.up_projection.biases is not None
+    assert loaded.experts.down_projection.biases is not None
+    expected_up_bias = jnp.broadcast_to(gate_up_bias[1::2] + 1, (2, 32))
+    expected_gate_bias = jnp.broadcast_to(gate_up_bias[0::2], (2, 32))
+    assert jnp.array_equal(loaded.experts.up_projection.biases[..., :32], expected_up_bias)
+    assert jnp.array_equal(loaded.experts.up_projection.biases[..., 32:], expected_gate_bias)
+    assert jnp.array_equal(loaded.experts.down_projection.biases, jnp.broadcast_to(down_bias, (2, 64)))
 
 
 def test_load_huggingface_classifier_uses_hf_embedding_layout() -> None:


### PR DESCRIPTION
This change set reuses Lalamo's existing MXFP4/Microfloat format for GPT-OSS and adds an opt-in interleaved gate/up layout, leaving the existing split layout as the default so other pipelines remain unchanged when GPT-OSS experts no longer expand to BF16.