### PR TITLE
Fuse gated attention projections

### DIFF
--- a/lalamo/model_import/loaders/fishaudio_loaders.py
+++ b/lalamo/model_import/loaders/fishaudio_loaders.py
@@ -202,27 +202,27 @@ def load_transformer_block(
         path: ParameterPath,
         scaling_to_fuse: Array | None = None,
     ) -> Attention:
-        qkv_projection = load_linear_and_fuse_scaling(
-            attn_module.qkv_projection,
+        qkvg_projection = load_linear_and_fuse_scaling(
+            attn_module.qkvg_projection,
             weights_dict,
             path / "wqkv",
             sublayers_to_fuse=None,
         )
-        assert isinstance(qkv_projection, Linear)
+        assert isinstance(qkvg_projection, Linear)
 
         # Permute QKV weights from interleaved RoPE format to rotate-half format
         permuted_qkv_weights = _permute_qkv_for_rope_rotate_half(
-            qkv_projection.weights.decompress(),
+            qkvg_projection.weights.decompress(),
             num_heads=attn_module.config.num_heads,
             num_groups=attn_module.config.num_groups,
             head_dim=attn_module.config.head_dim,
         )
-        new_weights = qkv_projection.weights.spec.compress(
+        new_weights = qkvg_projection.weights.spec.compress(
             permuted_qkv_weights,
-            sharding_config=qkv_projection.weights.sharding_config,
+            sharding_config=qkvg_projection.weights.sharding_config,
         )
-        qkv_projection = eqx.tree_at(lambda m: (m.weights,), qkv_projection, (new_weights,))
-        assert isinstance(qkv_projection, Linear)
+        qkvg_projection = eqx.tree_at(lambda m: (m.weights,), qkvg_projection, (new_weights,))
+        assert isinstance(qkvg_projection, Linear)
 
         out_projection = load_linear_and_fuse_scaling(
             attn_module.out_projection,
@@ -235,9 +235,9 @@ def load_transformer_block(
         key_norm = _load_rope_norm(attn_module.key_norm, weights_dict, path / "k_norm")
 
         return load_as_at(
-            lambda m: (m.qkv_projection, m.out_projection, m.query_norm, m.key_norm),
+            lambda m: (m.qkvg_projection, m.out_projection, m.query_norm, m.key_norm),
             attn_module,
-            (qkv_projection, out_projection, query_norm, key_norm),
+            (qkvg_projection, out_projection, query_norm, key_norm),
         )
 
     def load_mlp(

--- a/lalamo/model_import/loaders/huggingface.py
+++ b/lalamo/model_import/loaders/huggingface.py
@@ -686,29 +686,36 @@ def _split_q_gate_tensor(
     return q, gate
 
 
-def _extract_gate_weights(
+def _reorder_gated_attention_weights(
     weights_dict: Mapping[str, Array],
     path: ParameterPath,
     num_heads: int,
     head_dim: int,
-) -> tuple[dict[str, Array], dict[str, Array]]:
+) -> dict[str, Array]:
+    """Split Qwen's per-head-interleaved Q/G projection into synthetic Q and G sublayers."""
     q_proj_path = path / "q_proj"
+    if (q_proj_path / "qweight") in weights_dict:
+        raise ValueError(
+            "Packed qweight is not supported for gated attention; Q/G reordering requires "
+            "format-aware output-channel unpacking. Use a full-precision or MLX checkpoint.",
+        )
+
     q_proj_prefix = f"{q_proj_path}."
     kv_proj_prefixes = (f"{path / 'k_proj'}.", f"{path / 'v_proj'}.")
-    gate_path = path / "gate_projection"
-    q_weights: dict[str, Array] = {}
-    gate_weights: dict[str, Array] = {}
+    # g_proj exists only in this normalized mapping so the generic linear loader can fuse Q/K/V/G.
+    gate_path = path / "g_proj"
+    reordered_weights: dict[str, Array] = {}
 
     for key in weights_dict:
         if key.startswith(q_proj_prefix):
             suffix = key[len(q_proj_prefix) :]
             tensor = weights_dict[key]
             q_part, gate_part = _split_q_gate_tensor(tensor, num_heads, head_dim)
-            q_weights[key] = q_part
-            gate_weights[gate_path / suffix] = gate_part
+            reordered_weights[key] = q_part
+            reordered_weights[gate_path / suffix] = gate_part
         elif key.startswith(kv_proj_prefixes):
-            q_weights[key] = weights_dict[key]
-    return q_weights, gate_weights
+            reordered_weights[key] = weights_dict[key]
+    return reordered_weights
 
 
 def load_attention(
@@ -718,57 +725,27 @@ def load_attention(
     *,
     implementation: CompressionImplementation = CompressionImplementation.INFERENCE,
 ) -> Attention:
-    qkv_sublayers = ["q_proj"] if module.config.is_kv_sharing else ["q_proj", "k_proj", "v_proj"]
-    has_separate_gate = (path / "gate_proj" / "weight") in weights_dict or (
-        path / "gate_proj" / "qweight"
-    ) in weights_dict
-    if module.gate_projection is not None and has_separate_gate:
-        qkv_projection = load_linear(
-            module.qkv_projection,
-            weights_dict,
-            path,
-            sublayers_to_fuse=qkv_sublayers,
-            implementation=implementation,
-        )
-        gate_projection = load_linear(
-            module.gate_projection,
-            weights_dict,
-            path / "gate_proj",
-            implementation=implementation,
-        )
-    elif module.gate_projection is not None:
-        num_heads, head_dim = module.config.num_heads, module.config.head_dim
+    projection_sublayers = ["q_proj"] if module.config.is_kv_sharing else ["q_proj", "k_proj", "v_proj"]
+    projection_weights = weights_dict
+    if module.config.has_gate:
+        if (path / "gate_proj" / "weight") in weights_dict or (path / "gate_proj" / "qweight") in weights_dict:
+            projection_sublayers = [*projection_sublayers, "gate_proj"]
+        else:
+            projection_weights = _reorder_gated_attention_weights(
+                weights_dict,
+                path,
+                module.config.num_heads,
+                module.config.head_dim,
+            )
+            projection_sublayers = [*projection_sublayers, "g_proj"]
 
-        qkv_weights, gate_weights = _extract_gate_weights(
-            weights_dict,
-            path,
-            num_heads,
-            head_dim,
-        )
-
-        qkv_projection = load_linear(
-            module.qkv_projection,
-            qkv_weights,
-            path,
-            sublayers_to_fuse=qkv_sublayers,
-            implementation=implementation,
-        )
-
-        gate_projection = load_linear(
-            module.gate_projection,
-            gate_weights,
-            path / "gate_projection",
-            implementation=implementation,
-        )
-    else:
-        qkv_projection = load_linear(
-            module.qkv_projection,
-            weights_dict,
-            path,
-            sublayers_to_fuse=qkv_sublayers,
-            implementation=implementation,
-        )
-        gate_projection = None
+    qkvg_projection = load_linear(
+        module.qkvg_projection,
+        projection_weights,
+        path,
+        sublayers_to_fuse=projection_sublayers,
+        implementation=implementation,
+    )
 
     out_projection = load_linear(
         module.out_projection,
@@ -783,15 +760,14 @@ def load_attention(
 
     return load_as_at(
         lambda m: (
-            m.qkv_projection,
-            m.gate_projection,
+            m.qkvg_projection,
             m.out_projection,
             m.query_norm,
             m.key_norm,
             m.sinks,
         ),
         module,
-        (qkv_projection, gate_projection, out_projection, query_norm, key_norm, sinks),
+        (qkvg_projection, out_projection, query_norm, key_norm, sinks),
     )
 
 
@@ -1378,8 +1354,8 @@ def load_huggingface_classifier(
         weights_dict: Mapping[str, Array],
         path: ParameterPath,
     ) -> Attention:
-        qkv_projection = load_linear(
-            module.qkv_projection,
+        qkvg_projection = load_linear(
+            module.qkvg_projection,
             weights_dict,
             path / "Wqkv",
             sublayers_to_fuse=None,
@@ -1391,9 +1367,9 @@ def load_huggingface_classifier(
         key_norm = _load_optional_rmsnorm(module.key_norm, weights_dict, path / "k_norm")
 
         return load_as_at(
-            lambda m: (m.qkv_projection, m.out_projection, m.query_norm, m.key_norm),
+            lambda m: (m.qkvg_projection, m.out_projection, m.query_norm, m.key_norm),
             module,
-            (qkv_projection, out_projection, query_norm, key_norm),
+            (qkvg_projection, out_projection, query_norm, key_norm),
         )
 
     def load_mlp_local(module: MLPBase, weights_dict: Mapping[str, Array], path: ParameterPath) -> MLPBase:

--- a/lalamo/model_import/model_configs/huggingface/bonsai.py
+++ b/lalamo/model_import/model_configs/huggingface/bonsai.py
@@ -100,13 +100,13 @@ class HFBonsaiConfig(HuggingFaceLMConfig):
         )
 
         attention_config = AttentionConfig(
-            qkv_projection_config=linear_config,
+            qkvg_projection_config=linear_config,
             out_projection_config=linear_config,
             query_norm_config=rmsnorm_config,
             key_norm_config=rmsnorm_config,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=self.attention_bias,
+            has_qkvg_biases=self.attention_bias,
             has_out_biases=self.attention_bias,
             num_heads=self.num_attention_heads,
             num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/dflash.py
+++ b/lalamo/model_import/model_configs/huggingface/dflash.py
@@ -172,7 +172,7 @@ class HFDFlashConfig:
             TransformerLayerConfig(
                 pre_mixer_norm_config=norm_config,
                 mixer_config=AttentionConfig(
-                    qkv_projection_config=linear_config,
+                    qkvg_projection_config=linear_config,
                     out_projection_config=linear_config,
                     query_norm_config=norm_config,
                     key_norm_config=norm_config,
@@ -184,7 +184,7 @@ class HFDFlashConfig:
                     sliding_window_size=2 * sliding_window_size - 1 if sliding_window_size is not None else None,
                     logit_soft_cap=None,
                     has_sinks=False,
-                    has_qkv_biases=self.attention_bias,
+                    has_qkvg_biases=self.attention_bias,
                     has_out_biases=self.attention_bias,
                 ),
                 post_mixer_norm_config=None,

--- a/lalamo/model_import/model_configs/huggingface/fishaudio.py
+++ b/lalamo/model_import/model_configs/huggingface/fishaudio.py
@@ -80,7 +80,7 @@ def lalamo_transformer_cfg_from_fish_audio_codec_cfg(
 
     linear_config = LinearConfig()
     mixer_config = AttentionConfig(
-        qkv_projection_config=linear_config,
+        qkvg_projection_config=linear_config,
         out_projection_config=linear_config,
         query_norm_config=None,
         key_norm_config=None,
@@ -92,7 +92,7 @@ def lalamo_transformer_cfg_from_fish_audio_codec_cfg(
         sliding_window_size=window_size,
         logit_soft_cap=None,
         has_sinks=False,
-        has_qkv_biases=False,
+        has_qkvg_biases=False,
         has_out_biases=False,
     )
 
@@ -286,7 +286,7 @@ class FishAudioConfig(ForeignTTSConfig):
 
         linear_config = LinearConfig()
         mixer_config = AttentionConfig(
-            qkv_projection_config=linear_config,
+            qkvg_projection_config=linear_config,
             out_projection_config=linear_config,
             query_norm_config=norm_config if attention_qk_norm else None,
             key_norm_config=norm_config if attention_qk_norm else None,
@@ -298,7 +298,7 @@ class FishAudioConfig(ForeignTTSConfig):
             sliding_window_size=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=False,
+            has_qkvg_biases=False,
             has_out_biases=False,
         )
 

--- a/lalamo/model_import/model_configs/huggingface/gemma2.py
+++ b/lalamo/model_import/model_configs/huggingface/gemma2.py
@@ -86,13 +86,13 @@ class HFGemma2Config(HuggingFaceLMConfig):
         for i in range(self.num_hidden_layers):
             sliding_window_size = self.sliding_window if not bool(i % 2) else None
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=None,
                 key_norm_config=None,
                 logit_soft_cap=self.attn_logit_softcapping,
                 has_sinks=False,
-                has_qkv_biases=self.attention_bias,
+                has_qkvg_biases=self.attention_bias,
                 has_out_biases=False,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/gemma3.py
+++ b/lalamo/model_import/model_configs/huggingface/gemma3.py
@@ -133,13 +133,13 @@ class HFGemma3TextConfigRaw:
         layer_configs = []
         for sliding_window_size in self.sliding_window_sizes:
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=rms_norm_config,
                 key_norm_config=rms_norm_config,
                 logit_soft_cap=self.attn_logit_softcapping,
                 has_sinks=False,
-                has_qkv_biases=self.attention_bias,
+                has_qkvg_biases=self.attention_bias,
                 has_out_biases=self.attention_bias,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/gemma4.py
+++ b/lalamo/model_import/model_configs/huggingface/gemma4.py
@@ -178,13 +178,13 @@ class HFGemma4TextConfig:
                 num_kv_heads = self.num_global_key_value_heads
 
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=rms_norm_config,
                 key_norm_config=rms_norm_config,
                 logit_soft_cap=None,
                 has_sinks=False,
-                has_qkv_biases=self.attention_bias,
+                has_qkvg_biases=self.attention_bias,
                 has_out_biases=self.attention_bias,
                 num_heads=self.num_attention_heads,
                 num_groups=num_kv_heads,

--- a/lalamo/model_import/model_configs/huggingface/gpt_oss.py
+++ b/lalamo/model_import/model_configs/huggingface/gpt_oss.py
@@ -155,13 +155,13 @@ class HFGPTOssConfig(HuggingFaceLMConfig):
         layer_configs = []
         for sliding_window_size in sliding_window_sizes:
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=None,
                 key_norm_config=None,
                 logit_soft_cap=None,
                 has_sinks=True,
-                has_qkv_biases=self.attention_bias,
+                has_qkvg_biases=self.attention_bias,
                 has_out_biases=self.attention_bias,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/granite.py
+++ b/lalamo/model_import/model_configs/huggingface/granite.py
@@ -79,13 +79,13 @@ class HFGraniteConfig(HuggingFaceLMConfig):
         )
         linear_config = LinearConfig()
         attention_config = AttentionConfig(
-            qkv_projection_config=linear_config,
+            qkvg_projection_config=linear_config,
             out_projection_config=linear_config,
             query_norm_config=None,
             key_norm_config=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=self.attention_bias,
+            has_qkvg_biases=self.attention_bias,
             has_out_biases=False,
             num_heads=self.num_attention_heads,
             num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/lfm2.py
+++ b/lalamo/model_import/model_configs/huggingface/lfm2.py
@@ -129,7 +129,7 @@ class HFLFM2Config(HuggingFaceLMConfig):
         )
 
         attention_config = AttentionConfig(
-            qkv_projection_config=linear_config,
+            qkvg_projection_config=linear_config,
             out_projection_config=linear_config,
             query_norm_config=block_norm_config,
             key_norm_config=block_norm_config,
@@ -141,7 +141,7 @@ class HFLFM2Config(HuggingFaceLMConfig):
             sliding_window_size=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=False,
+            has_qkvg_biases=False,
             has_out_biases=False,
         )
 

--- a/lalamo/model_import/model_configs/huggingface/llama.py
+++ b/lalamo/model_import/model_configs/huggingface/llama.py
@@ -122,13 +122,13 @@ class HFLlamaConfig(HuggingFaceLMConfig):
         )
         linear_config = LinearConfig()
         attention_config = AttentionConfig(
-            qkv_projection_config=linear_config,
+            qkvg_projection_config=linear_config,
             out_projection_config=linear_config,
             query_norm_config=None,
             key_norm_config=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=self.attention_bias,
+            has_qkvg_biases=self.attention_bias,
             has_out_biases=False,
             num_heads=self.num_attention_heads,
             num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/mistral.py
+++ b/lalamo/model_import/model_configs/huggingface/mistral.py
@@ -88,13 +88,13 @@ class HFMistralConfig(HuggingFaceLMConfig):
         layer_configs = []
         for _ in range(self.num_hidden_layers):
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=None,
                 key_norm_config=None,
                 logit_soft_cap=None,
                 has_sinks=False,
-                has_qkv_biases=False,
+                has_qkvg_biases=False,
                 has_out_biases=False,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/modern_bert.py
+++ b/lalamo/model_import/model_configs/huggingface/modern_bert.py
@@ -132,13 +132,13 @@ class ModernBERTConfig(HuggingFaceClassifierConfig):
         transformer_layer_configs = []
         for sliding_window_size, pre_attn_config in zip(sliding_window_sizes, pre_attn_configs, strict=True):
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=None,
                 key_norm_config=None,
                 logit_soft_cap=None,
                 has_sinks=False,
-                has_qkv_biases=self.attention_bias,
+                has_qkvg_biases=self.attention_bias,
                 has_out_biases=False,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_attention_heads,

--- a/lalamo/model_import/model_configs/huggingface/muse_glimmer.py
+++ b/lalamo/model_import/model_configs/huggingface/muse_glimmer.py
@@ -156,13 +156,13 @@ class HFMuseGlimmerTextConfig:
                 sliding_window_size = None
 
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=qk_norm_config,
                 key_norm_config=qk_norm_config,
                 logit_soft_cap=None,
                 has_sinks=False,
-                has_qkv_biases=self.attention_bias,
+                has_qkvg_biases=self.attention_bias,
                 has_out_biases=self.attention_bias,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,
@@ -170,7 +170,7 @@ class HFMuseGlimmerTextConfig:
                 is_causal=True,
                 scale=attention_scale,
                 sliding_window_size=sliding_window_size,
-                gate_projection_config=linear_config,
+                has_gate=True,
             )
             transformer_layer_config = TransformerLayerConfig(
                 pre_mixer_norm_config=pre_norm_config,

--- a/lalamo/model_import/model_configs/huggingface/phi3.py
+++ b/lalamo/model_import/model_configs/huggingface/phi3.py
@@ -103,13 +103,13 @@ class HFPhi3Config(HuggingFaceLMConfig):
         layer_configs = []
         for _ in range(self.num_hidden_layers):
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=None,
                 key_norm_config=None,
                 logit_soft_cap=None,
                 has_sinks=False,
-                has_qkv_biases=False,
+                has_qkvg_biases=False,
                 has_out_biases=False,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/qwen2.py
+++ b/lalamo/model_import/model_configs/huggingface/qwen2.py
@@ -100,13 +100,13 @@ class HFQwen2Config(HuggingFaceLMConfig):
         layer_configs = []
         for sliding_window_size in sliding_window_sizes:
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=None,
                 key_norm_config=None,
                 logit_soft_cap=None,
                 has_sinks=False,
-                has_qkv_biases=True,
+                has_qkvg_biases=True,
                 has_out_biases=False,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/qwen3.py
+++ b/lalamo/model_import/model_configs/huggingface/qwen3.py
@@ -98,13 +98,13 @@ class HFQwen3Config(HuggingFaceLMConfig):
         layer_configs = []
         for sliding_window_size in sliding_window_sizes:
             attention_config = AttentionConfig(
-                qkv_projection_config=linear_config,
+                qkvg_projection_config=linear_config,
                 out_projection_config=linear_config,
                 query_norm_config=rmsnorm_config,
                 key_norm_config=rmsnorm_config,
                 logit_soft_cap=None,
                 has_sinks=False,
-                has_qkv_biases=self.attention_bias,
+                has_qkvg_biases=self.attention_bias,
                 has_out_biases=self.attention_bias,
                 num_heads=self.num_attention_heads,
                 num_groups=self.num_key_value_heads,

--- a/lalamo/model_import/model_configs/huggingface/qwen3_5.py
+++ b/lalamo/model_import/model_configs/huggingface/qwen3_5.py
@@ -167,13 +167,13 @@ class HFQwen35Config(HuggingFaceLMConfig):
                 )
             else:
                 mixer_config = AttentionConfig(
-                    qkv_projection_config=linear_config,
+                    qkvg_projection_config=linear_config,
                     out_projection_config=linear_config,
                     query_norm_config=rmsnorm_config,
                     key_norm_config=rmsnorm_config,
                     logit_soft_cap=None,
                     has_sinks=False,
-                    has_qkv_biases=self.attention_bias,
+                    has_qkvg_biases=self.attention_bias,
                     has_out_biases=self.attention_bias,
                     num_heads=self.num_attention_heads,
                     num_groups=self.num_key_value_heads,
@@ -181,7 +181,7 @@ class HFQwen35Config(HuggingFaceLMConfig):
                     is_causal=True,
                     scale=None,
                     sliding_window_size=None,
-                    gate_projection_config=linear_config,
+                    has_gate=True,
                 )
 
             layer_configs.append(

--- a/lalamo/model_import/model_configs/huggingface/qwen3_next.py
+++ b/lalamo/model_import/model_configs/huggingface/qwen3_next.py
@@ -153,13 +153,13 @@ class HFQwen3NextConfig(HuggingFaceLMConfig):
                 )
             else:
                 mixer_config = AttentionConfig(
-                    qkv_projection_config=linear_config,
+                    qkvg_projection_config=linear_config,
                     out_projection_config=linear_config,
                     query_norm_config=rmsnorm_config,
                     key_norm_config=rmsnorm_config,
                     logit_soft_cap=None,
                     has_sinks=False,
-                    has_qkv_biases=self.attention_bias,
+                    has_qkvg_biases=self.attention_bias,
                     has_out_biases=self.attention_bias,
                     num_heads=self.num_attention_heads,
                     num_groups=self.num_key_value_heads,
@@ -167,7 +167,7 @@ class HFQwen3NextConfig(HuggingFaceLMConfig):
                     is_causal=True,
                     scale=None,
                     sliding_window_size=None,
-                    gate_projection_config=linear_config,
+                    has_gate=True,
                 )
 
             if (

--- a/lalamo/model_import/model_configs/huggingface/smollm3.py
+++ b/lalamo/model_import/model_configs/huggingface/smollm3.py
@@ -89,13 +89,13 @@ class HFSmolLM3Config(HuggingFaceLMConfig):
         uses_rope_by_layer = tuple(bool(flag) for flag in self.no_rope_layers[: self.num_hidden_layers])
 
         attention_config = AttentionConfig(
-            qkv_projection_config=linear_config,
+            qkvg_projection_config=linear_config,
             out_projection_config=linear_config,
             query_norm_config=None,
             key_norm_config=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=self.attention_bias,
+            has_qkvg_biases=self.attention_bias,
             has_out_biases=self.attention_bias,
             num_heads=self.num_attention_heads,
             num_groups=self.num_key_value_heads,

--- a/lalamo/modules/speculators/dflash.py
+++ b/lalamo/modules/speculators/dflash.py
@@ -149,12 +149,12 @@ class DFlashDraftModel(LalamoModule[DFlashDraftConfig]):
     output_norm: Normalization
 
     def state_kv_projection_from_layers(self, layers: tuple[TransformerLayer, ...]) -> Linear:
-        qkv_projections = tuple(_layer_attention(layer).qkv_projection for layer in layers)
+        qkvg_projections = tuple(_layer_attention(layer).qkvg_projection for layer in layers)
         key_value_weights = jnp.concatenate(
-            tuple(projection.weights.decompress()[projection.output_dims[0] :] for projection in qkv_projections),
+            tuple(projection.weights.decompress()[projection.output_dims[0] :] for projection in qkvg_projections),
             axis=0,
         )
-        weights = qkv_projections[0].weights.spec.compress(
+        weights = qkvg_projections[0].weights.spec.compress(
             key_value_weights,
             key=jax.random.key(0),
             sharding_config=self.state_kv_projection.weights.sharding_config,

--- a/lalamo/modules/token_mixers/attention.py
+++ b/lalamo/modules/token_mixers/attention.py
@@ -334,7 +334,8 @@ AttentionResult = TokenMixerResult[KVCacheLayer]
 
 @dataclass(frozen=True)
 class AttentionConfig(TokenMixerConfig):
-    qkv_projection_config: LinearConfig
+    # Unified QKVG projection; ungated attention omits the G output segment.
+    qkvg_projection_config: LinearConfig
     out_projection_config: LinearConfig
 
     query_norm_config: NormalizationConfig | None
@@ -349,9 +350,10 @@ class AttentionConfig(TokenMixerConfig):
 
     logit_soft_cap: float | None
     has_sinks: bool
-    has_qkv_biases: bool
+    has_qkvg_biases: bool
     has_out_biases: bool
-    gate_projection_config: LinearConfig | None = None
+    # Query-width sigmoid gate appended as the final fused projection segment.
+    has_gate: bool = False
     # Scale-free RMS normalization on values
     normalize_values: bool = False
     is_kv_sharing: bool = False
@@ -370,11 +372,14 @@ class AttentionConfig(TokenMixerConfig):
                 self.num_groups * self.head_dim,
                 self.num_groups * self.head_dim,
             )
-        qkv_projection = self.qkv_projection_config.init(
+        if self.has_gate:
+            output_dims = (*output_dims, q_output_dim)
+
+        qkvg_projection = self.qkvg_projection_config.init(
             initializer,
             input_dim=model_dim,
             output_dims=output_dims,
-            has_biases=self.has_qkv_biases,
+            has_biases=self.has_qkvg_biases,
         )
         out_projection = self.out_projection_config.init(
             initializer,
@@ -382,16 +387,6 @@ class AttentionConfig(TokenMixerConfig):
             (model_dim,),
             has_biases=self.has_out_biases,
         )
-
-        if self.gate_projection_config is not None:
-            gate_projection = self.gate_projection_config.init(
-                initializer,
-                input_dim=model_dim,
-                output_dims=(q_output_dim,),
-                has_biases=False,
-            )
-        else:
-            gate_projection = None
 
         if self.query_norm_config is not None:
             query_norm = self.query_norm_config.init(
@@ -417,8 +412,7 @@ class AttentionConfig(TokenMixerConfig):
         return Attention(
             config=self,
             sharding_config=initializer.sharding_config,
-            qkv_projection=qkv_projection,
-            gate_projection=gate_projection,
+            qkvg_projection=qkvg_projection,
             out_projection=out_projection,
             query_norm=query_norm,
             key_norm=key_norm,
@@ -427,8 +421,7 @@ class AttentionConfig(TokenMixerConfig):
 
 
 class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
-    qkv_projection: Linear
-    gate_projection: Linear | None
+    qkvg_projection: Linear
     out_projection: Linear
 
     query_norm: Normalization | None
@@ -438,7 +431,7 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
 
     @property
     def model_dim(self) -> int:
-        return self.qkv_projection.input_dim
+        return self.qkvg_projection.input_dim
 
     @property
     def use_sliding_window(self) -> bool:
@@ -492,8 +485,8 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
     ]:
         if self.config.is_kv_sharing:
             raise ValueError("KV-sharing attention layers do not own key/value projections.")
-        _, keys, values = call_vmapped(
-            self.qkv_projection,
+        _, keys, values, *_ = call_vmapped(
+            self.qkvg_projection,
             inputs,
             forward_pass_config=forward_pass_config.matmul_config,
             keychain=keychain,
@@ -528,22 +521,17 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
         *,
         keychain: Keychain,
     ) -> AttentionResult:
-        qkv_keychain, gate_keychain, out_keychain = keychain.split(3)
+        qkvg_keychain, out_keychain = keychain.split(2)
         assert reuse_cache == self.config.is_kv_sharing, "reuse_cache must match AttentionConfig.is_kv_sharing"
         projections = call_vmapped(
-            self.qkv_projection,
+            self.qkvg_projection,
             inputs,
             forward_pass_config=forward_pass_config.matmul_config,
-            keychain=qkv_keychain,
+            keychain=qkvg_keychain,
         )
         queries = projections[0]
-        if self.gate_projection is not None:
-            (gate,) = call_vmapped(
-                self.gate_projection,
-                inputs,
-                forward_pass_config=forward_pass_config.matmul_config,
-                keychain=gate_keychain,
-            )
+        if self.config.has_gate:
+            gate = projections[-1]
         else:
             gate = None
 
@@ -558,7 +546,7 @@ class Attention(TokenMixerBase[AttentionConfig, KVCacheLayer]):
             prefix_length = state.current_prefix_length() - num_suffix_tokens
             updated_state = state
         else:
-            _, keys, values = projections
+            _, keys, values, *_ = projections
             prefix_length = 0 if state is None else state.current_prefix_length()
             keys = self._prepare_heads(
                 keys, self.config.num_groups, self.key_norm, positional_embeddings, forward_pass_config

--- a/tests/coherence/test_tokamax_equivalence.py
+++ b/tests/coherence/test_tokamax_equivalence.py
@@ -43,7 +43,7 @@ def _attention() -> Attention:
     qkv_dim = NUM_HEADS * HEAD_DIM
     return Attention(
         config=AttentionConfig(
-            qkv_projection_config=LinearConfig(),
+            qkvg_projection_config=LinearConfig(),
             out_projection_config=LinearConfig(),
             query_norm_config=None,
             key_norm_config=None,
@@ -55,13 +55,11 @@ def _attention() -> Attention:
             sliding_window_size=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=False,
+            has_qkvg_biases=False,
             has_out_biases=False,
-            gate_projection_config=None,
         ),
         sharding_config=make_test_sharding_config(),
-        qkv_projection=_linear(_weights((3 * qkv_dim, MODEL_DIM)), (qkv_dim, qkv_dim, qkv_dim)),
-        gate_projection=None,
+        qkvg_projection=_linear(_weights((3 * qkv_dim, MODEL_DIM)), (qkv_dim, qkv_dim, qkv_dim)),
         out_projection=_linear(_weights((MODEL_DIM, qkv_dim), offset=100), (MODEL_DIM,)),
         query_norm=None,
         key_norm=None,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -93,7 +93,7 @@ def build_tiny_attention_decoder(kv_source_layer_indices: tuple[int | None, ...]
     layer_configs = []
     for kv_source in kv_source_layer_indices:
         attention_config = AttentionConfig(
-            qkv_projection_config=LinearConfig(),
+            qkvg_projection_config=LinearConfig(),
             out_projection_config=LinearConfig(),
             query_norm_config=None,
             key_norm_config=None,
@@ -105,7 +105,7 @@ def build_tiny_attention_decoder(kv_source_layer_indices: tuple[int | None, ...]
             sliding_window_size=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=False,
+            has_qkvg_biases=False,
             has_out_biases=False,
             is_kv_sharing=kv_source is not None,
         )

--- a/tests/tts/fishaudio/fishaudio_torch_stuff.py
+++ b/tests/tts/fishaudio/fishaudio_torch_stuff.py
@@ -143,7 +143,7 @@ class ConfigMapping:
 
         linear_config = LinearConfig()
         mixer_config = AttentionConfig(
-            qkv_projection_config=linear_config,
+            qkvg_projection_config=linear_config,
             out_projection_config=linear_config,
             query_norm_config=norm_config if config.attention_qk_norm else None,
             key_norm_config=norm_config if config.attention_qk_norm else None,
@@ -155,7 +155,7 @@ class ConfigMapping:
             sliding_window_size=None,
             logit_soft_cap=None,
             has_sinks=False,
-            has_qkv_biases=False,
+            has_qkvg_biases=False,
             has_out_biases=False,
         )
 

--- a/tests/unit/modules/test_attention.py
+++ b/tests/unit/modules/test_attention.py
@@ -37,11 +37,19 @@ def _linear(weights: Array, output_dims: tuple[int, ...]) -> Linear:
     )
 
 
-def _attention(*, logit_soft_cap: float | None = None) -> Attention:
+def _attention(
+    *,
+    logit_soft_cap: float | None = None,
+    has_gate: bool = False,
+    is_kv_sharing: bool = False,
+) -> Attention:
     qkv_dim = NUM_HEADS * HEAD_DIM
+    output_dims = (qkv_dim,) if is_kv_sharing else (qkv_dim, qkv_dim, qkv_dim)
+    if has_gate:
+        output_dims = (*output_dims, qkv_dim)
     return Attention(
         config=AttentionConfig(
-            qkv_projection_config=LinearConfig(),
+            qkvg_projection_config=LinearConfig(),
             out_projection_config=LinearConfig(),
             query_norm_config=None,
             key_norm_config=None,
@@ -53,13 +61,13 @@ def _attention(*, logit_soft_cap: float | None = None) -> Attention:
             sliding_window_size=None,
             logit_soft_cap=logit_soft_cap,
             has_sinks=False,
-            has_qkv_biases=False,
+            has_qkvg_biases=False,
             has_out_biases=False,
-            gate_projection_config=None,
+            has_gate=has_gate,
+            is_kv_sharing=is_kv_sharing,
         ),
         sharding_config=make_test_sharding_config(),
-        qkv_projection=_linear(_weights((3 * qkv_dim, MODEL_DIM)), (qkv_dim, qkv_dim, qkv_dim)),
-        gate_projection=None,
+        qkvg_projection=_linear(_weights((sum(output_dims), MODEL_DIM)), output_dims),
         out_projection=_linear(_weights((MODEL_DIM, qkv_dim), offset=100), (MODEL_DIM,)),
         query_norm=None,
         key_norm=None,
@@ -75,7 +83,8 @@ def _linear_reference(linear: Linear, inputs: Array) -> tuple[Array, ...]:
 
 def _reference(module: Attention, inputs: Array) -> Array:
     inputs = jnp.asarray(jax.device_get(inputs))
-    queries, keys, values = _linear_reference(module.qkv_projection, inputs)
+    projections = _linear_reference(module.qkvg_projection, inputs)
+    queries, keys, values, *_ = projections
     queries = rearrange(queries, "tokens (heads channels) -> tokens heads channels", heads=NUM_HEADS)
     keys = rearrange(keys, "tokens (groups channels) -> tokens groups channels", groups=NUM_GROUPS)
     values = rearrange(values, "tokens (groups channels) -> tokens groups channels", groups=NUM_GROUPS)
@@ -86,6 +95,8 @@ def _reference(module: Attention, inputs: Array) -> Array:
     attention_weights = jax.nn.softmax(logits, axis=-1)
     attention_output = jnp.einsum("hts,shc->thc", attention_weights, values)
     attention_output = rearrange(attention_output, "tokens heads channels -> tokens (heads channels)")
+    if module.config.has_gate:
+        attention_output = attention_output * jax.nn.sigmoid(projections[-1])
     (outputs,) = _linear_reference(module.out_projection, attention_output)
     return outputs
 
@@ -123,6 +134,59 @@ def test_attention_matches_reference_and_preserves_tensor_sharding(fake_mesh: Me
     _assert_named_sharding(result.outputs.sharding, fake_mesh)
     assert result.outputs.sharding == make_sharding((None, None))
     assert result.state is None
+
+
+def test_gated_attention_matches_reference(fake_mesh: Mesh) -> None:
+    module = _attention(has_gate=True)
+    inputs = _sharded_sequence(_inputs())
+
+    result = module(
+        inputs,
+        positional_embeddings=None,
+        keychain=Keychain.init(11, sharding_config=make_test_sharding_config()),
+    )
+
+    assert module.qkvg_projection.output_dims == (4, 4, 4, 4)
+    _assert_close(result=result.outputs, reference=_reference(module, inputs))
+    _assert_named_sharding(result.outputs.sharding, fake_mesh)
+
+
+def test_gated_kv_sharing_matches_equivalent_full_projection(fake_mesh: Mesh) -> None:
+    source = _attention()
+    query_gate = _attention(has_gate=True, is_kv_sharing=True)
+    query_weights, gate_weights = jnp.split(query_gate.qkvg_projection.weights.decompress(), 2)
+    _, key_weights, value_weights = jnp.split(source.qkvg_projection.weights.decompress(), 3)
+    full = _attention(has_gate=True)
+    full_projection = _linear(
+        jnp.concatenate((query_weights, key_weights, value_weights, gate_weights)),
+        (NUM_HEADS * HEAD_DIM,) * 4,
+    )
+    full = eqx.tree_at(lambda module: module.qkvg_projection, full, full_projection)
+    inputs = _sharded_sequence(_inputs())
+
+    source_result = source(
+        inputs,
+        positional_embeddings=None,
+        return_updated_state=True,
+        keychain=Keychain.init(12, sharding_config=make_test_sharding_config()),
+    )
+    assert source_result.state is not None
+    shared_result = query_gate(
+        inputs,
+        positional_embeddings=None,
+        state=source_result.state,
+        reuse_cache=True,
+        keychain=Keychain.init(13, sharding_config=make_test_sharding_config()),
+    )
+    full_result = full(
+        inputs,
+        positional_embeddings=None,
+        keychain=Keychain.init(14, sharding_config=make_test_sharding_config()),
+    )
+
+    assert query_gate.qkvg_projection.output_dims == (4, 4)
+    _assert_close(result=shared_result.outputs, reference=full_result.outputs)
+    _assert_named_sharding(shared_result.outputs.sharding, fake_mesh)
 
 
 def test_attention_returns_dynamic_state_with_tensor_sharding(fake_mesh: Mesh) -> None:
@@ -245,17 +309,16 @@ def test_attention_export_load_roundtrips_and_preserves_template_sharding(fake_m
     template = Attention(
         config=original.config,
         sharding_config=make_test_sharding_config(),
-        qkv_projection=Linear(
+        qkvg_projection=Linear(
             config=LinearConfig(),
             sharding_config=make_test_sharding_config(),
             weights=FullPrecisionSpec().compress(
-                dummy_array(original.qkv_projection.weights.shape, jnp.float32, weight_sharding),
+                dummy_array(original.qkvg_projection.weights.shape, jnp.float32, weight_sharding),
                 sharding_config=make_test_sharding_config(),
             ),
             biases=None,
-            output_dims=original.qkv_projection.output_dims,
+            output_dims=original.qkvg_projection.output_dims,
         ),
-        gate_projection=None,
         out_projection=Linear(
             config=LinearConfig(),
             sharding_config=make_test_sharding_config(),
@@ -277,11 +340,11 @@ def test_attention_export_load_roundtrips_and_preserves_template_sharding(fake_m
         inputs, positional_embeddings=None, keychain=Keychain.init(4, sharding_config=make_test_sharding_config())
     )
 
-    assert isinstance(restored.qkv_projection.weights, FullPrecisionMatrix)
+    assert isinstance(restored.qkvg_projection.weights, FullPrecisionMatrix)
     assert isinstance(restored.out_projection.weights, FullPrecisionMatrix)
-    assert isinstance(template.qkv_projection.weights, FullPrecisionMatrix)
+    assert isinstance(template.qkvg_projection.weights, FullPrecisionMatrix)
     assert isinstance(template.out_projection.weights, FullPrecisionMatrix)
-    assert restored.qkv_projection.weights.weights.sharding == template.qkv_projection.weights.weights.sharding
+    assert restored.qkvg_projection.weights.weights.sharding == template.qkvg_projection.weights.weights.sharding
     assert restored.out_projection.weights.weights.sharding == template.out_projection.weights.weights.sharding
     _assert_close(
         result=result.outputs,

--- a/tests/unit/modules/test_rope.py
+++ b/tests/unit/modules/test_rope.py
@@ -214,7 +214,7 @@ def _attention() -> Attention:
         subtract_mean=False,
     )
     config = AttentionConfig(
-        qkv_projection_config=LinearConfig(),
+        qkvg_projection_config=LinearConfig(),
         out_projection_config=LinearConfig(),
         query_norm_config=norm_config,
         key_norm_config=norm_config,
@@ -226,7 +226,7 @@ def _attention() -> Attention:
         sliding_window_size=None,
         logit_soft_cap=None,
         has_sinks=False,
-        has_qkv_biases=False,
+        has_qkvg_biases=False,
         has_out_biases=False,
     )
     return config.init(
@@ -267,9 +267,9 @@ def test_attention_project_key_value_heads_matches_cache_written_by_call(fake_me
     projected = jnp.einsum(
         "ti,oi->to",
         jnp.asarray(jax.device_get(inputs)),
-        jnp.asarray(jax.device_get(module.qkv_projection.weights.decompress())),
+        jnp.asarray(jax.device_get(module.qkvg_projection.weights.decompress())),
     )
-    *_, raw_values = jnp.split(projected, Linear.get_split_points(module.qkv_projection.output_dims), axis=-1)
+    *_, raw_values = jnp.split(projected, Linear.get_split_points(module.qkvg_projection.output_dims), axis=-1)
     _assert_close(
         result=values,
         reference=rearrange(raw_values, "tokens (groups head_channels) -> tokens groups head_channels", groups=2),

--- a/tests/unit/test_model_import_loading.py
+++ b/tests/unit/test_model_import_loading.py
@@ -16,6 +16,7 @@ from lalamo.compressed.mlx import MLXMatrixForInference, MLXMatrixForTraining
 from lalamo.initializer import EmptyInitializer, Initializer
 from lalamo.model import Model, ModelConfig
 from lalamo.model_import.loaders.huggingface import (
+    load_attention,
     load_huggingface_classifier,
     load_input_embedding_matrix,
     load_linear,
@@ -30,7 +31,7 @@ from lalamo.modules.embedding import TiedEmbedding
 from lalamo.modules.linear import Linear, LinearConfig
 from lalamo.modules.mlp import DenseMLP
 from lalamo.modules.normalization import NormalizationConfig, UpcastMode
-from lalamo.modules.token_mixers.attention import Attention
+from lalamo.modules.token_mixers.attention import Attention, AttentionConfig
 from lalamo.utils.dummy_array import dummy_array
 from lalamo.utils.parameter_path import ParameterPath
 from lalamo.weight_matrix import (
@@ -79,6 +80,27 @@ def _linear_template(dtype: DTypeLike | None, layout: Layout = Layout.OUTPUT_INP
         sharding_config=make_test_sharding_config(),
     )
     return eqx.tree_at(lambda module: module.weights, result, weights)
+
+
+def _gated_attention_template(dtype: DTypeLike, *, has_qkvg_biases: bool) -> Attention:
+    initializer = EmptyInitializer(default_dtype=dtype, sharding_config=make_test_sharding_config())
+    return AttentionConfig(
+        qkvg_projection_config=LinearConfig(),
+        out_projection_config=LinearConfig(),
+        query_norm_config=None,
+        key_norm_config=None,
+        num_heads=2,
+        num_groups=1,
+        head_dim=2,
+        is_causal=True,
+        scale=None,
+        sliding_window_size=None,
+        logit_soft_cap=None,
+        has_sinks=False,
+        has_qkvg_biases=has_qkvg_biases,
+        has_out_biases=False,
+        has_gate=True,
+    ).init(initializer, INPUT_DIM)
 
 
 def _mlx_weights(path: ParameterPath) -> Mapping[str, Array]:
@@ -181,7 +203,7 @@ def _classifier_weights(classifier: Classifier) -> Mapping[str, Array]:
         ),
         decoder_path / "embeddings" / "norm" / "weight": _classifier_tensor(classifier.embedding_norm.scales.shape),
         decoder_path / "layers" / 0 / "attn" / "Wqkv" / "weight": _classifier_tensor(
-            layer.mixer.qkv_projection.weights.shape,
+            layer.mixer.qkvg_projection.weights.shape,
         ),
         decoder_path / "layers" / 0 / "attn" / "Wo" / "weight": _classifier_tensor(
             layer.mixer.out_projection.weights.shape,
@@ -322,6 +344,96 @@ def test_load_linear_full_precision_strong_template_forces_template_dtype() -> N
 
     assert isinstance(loaded.weights, FullPrecisionMatrix)
     assert loaded.weights.dtype == jnp.float32
+
+
+def test_load_gated_attention_fuses_qkvg_weights_and_biases() -> None:
+    module = _gated_attention_template(jnp.float32, has_qkvg_biases=True)
+    num_heads = module.config.num_heads
+    num_groups = module.config.num_groups
+    head_dim = module.config.head_dim
+    q_dim = num_heads * head_dim
+    kv_dim = num_groups * head_dim
+    path = ParameterPath("self_attn")
+    qg_weights = jnp.arange(2 * q_dim * INPUT_DIM, dtype=jnp.float32).reshape(2 * q_dim, INPUT_DIM)
+    qg_biases = jnp.arange(2 * q_dim, dtype=jnp.float32)
+    k_weights = jnp.full((kv_dim, INPUT_DIM), 100, dtype=jnp.float32)
+    v_weights = jnp.full((kv_dim, INPUT_DIM), 200, dtype=jnp.float32)
+    k_biases = jnp.full((kv_dim,), 300, dtype=jnp.float32)
+    v_biases = jnp.full((kv_dim,), 400, dtype=jnp.float32)
+    weights: Mapping[str, Array] = {
+        path / "q_proj" / "weight": qg_weights,
+        path / "q_proj" / "bias": qg_biases,
+        path / "k_proj" / "weight": k_weights,
+        path / "k_proj" / "bias": k_biases,
+        path / "v_proj" / "weight": v_weights,
+        path / "v_proj" / "bias": v_biases,
+        path / "o_proj" / "weight": jnp.zeros((INPUT_DIM, q_dim), dtype=jnp.float32),
+    }
+
+    loaded = load_attention(module, weights, path)
+
+    qg_weights_by_head = qg_weights.reshape(num_heads, 2 * head_dim, INPUT_DIM)
+    q_weights = qg_weights_by_head[:, :head_dim].reshape(q_dim, INPUT_DIM)
+    gate_weights = qg_weights_by_head[:, head_dim:].reshape(q_dim, INPUT_DIM)
+    expected_weights = jnp.concatenate((q_weights, k_weights, v_weights, gate_weights))
+    qg_biases_by_head = qg_biases.reshape(num_heads, 2 * head_dim)
+    q_biases = qg_biases_by_head[:, :head_dim].reshape(q_dim)
+    gate_biases = qg_biases_by_head[:, head_dim:].reshape(q_dim)
+    expected_biases = jnp.concatenate((q_biases, k_biases, v_biases, gate_biases))
+
+    assert loaded.qkvg_projection.output_dims == (q_dim, kv_dim, kv_dim, q_dim)
+    np.testing.assert_array_equal(loaded.qkvg_projection.weights.decompress(), expected_weights)
+    np.testing.assert_array_equal(loaded.qkvg_projection.biases, expected_biases)
+
+
+def test_load_gated_attention_fuses_mlx_4bit_qkvg_weights() -> None:
+    module = _gated_attention_template(jnp.bfloat16, has_qkvg_biases=False)
+    num_heads = module.config.num_heads
+    head_dim = module.config.head_dim
+    q_dim = num_heads * head_dim
+    kv_dim = module.config.num_groups * head_dim
+    path = ParameterPath("self_attn")
+    qg_weights = jnp.arange(2 * q_dim * INPUT_DIM, dtype=jnp.int32).reshape(2 * q_dim, INPUT_DIM) % 16
+    k_weights = (jnp.arange(kv_dim * INPUT_DIM, dtype=jnp.int32).reshape(kv_dim, INPUT_DIM) + 3) % 16
+    v_weights = (jnp.arange(kv_dim * INPUT_DIM, dtype=jnp.int32).reshape(kv_dim, INPUT_DIM) + 7) % 16
+
+    def mlx_projection(projection_path: ParameterPath, unpacked_weights: Array) -> Mapping[str, Array]:
+        rows = unpacked_weights.shape[0]
+        return {
+            projection_path / "weight": _pack_int32(unpacked_weights, bits=4),
+            projection_path / "scales": jnp.ones((rows, NUM_GROUPS), dtype=jnp.bfloat16),
+            projection_path / "biases": jnp.zeros((rows, NUM_GROUPS), dtype=jnp.bfloat16),
+        }
+
+    weights = {
+        **mlx_projection(path / "q_proj", qg_weights),
+        **mlx_projection(path / "k_proj", k_weights),
+        **mlx_projection(path / "v_proj", v_weights),
+        path / "o_proj" / "weight": jnp.zeros((INPUT_DIM, q_dim), dtype=jnp.bfloat16),
+    }
+
+    loaded = load_attention(module, weights, path)
+
+    qg_weights_by_head = qg_weights.reshape(num_heads, 2 * head_dim, INPUT_DIM)
+    q_weights = qg_weights_by_head[:, :head_dim].reshape(q_dim, INPUT_DIM)
+    gate_weights = qg_weights_by_head[:, head_dim:].reshape(q_dim, INPUT_DIM)
+    expected_weights = jnp.concatenate((q_weights, k_weights, v_weights, gate_weights)).astype(jnp.bfloat16)
+
+    assert isinstance(loaded.qkvg_projection.weights, MLXMatrixForInference)
+    assert loaded.qkvg_projection.weights.spec.bits == 4
+    assert loaded.qkvg_projection.output_dims == (q_dim, kv_dim, kv_dim, q_dim)
+    np.testing.assert_array_equal(loaded.qkvg_projection.weights.decompress(), expected_weights)
+
+
+def test_load_gated_attention_rejects_packed_qweight_with_clear_error() -> None:
+    module = _gated_attention_template(jnp.bfloat16, has_qkvg_biases=False)
+    path = ParameterPath("self_attn")
+    weights: Mapping[str, Array] = {
+        path / "q_proj" / "qweight": jnp.zeros((INPUT_DIM, 1), dtype=jnp.int32),
+    }
+
+    with pytest.raises(ValueError, match="Packed qweight is not supported for gated attention"):
+        load_attention(module, weights, path)
 
 
 def test_load_huggingface_classifier_uses_hf_embedding_layout() -> None:

--- a/tests/unit/test_tree_attention.py
+++ b/tests/unit/test_tree_attention.py
@@ -133,8 +133,8 @@ def test_kv_sharing_layer_projects_queries_only(decoder: Decoder) -> None:
     shared = decoder.transformer.layers[1].mixer
     assert isinstance(owner, Attention)
     assert isinstance(shared, Attention)
-    assert owner.qkv_projection.output_dims == (8, 8, 8)
-    assert shared.qkv_projection.output_dims == (8,)
+    assert owner.qkvg_projection.output_dims == (8, 8, 8)
+    assert shared.qkvg_projection.output_dims == (8,)
     assert shared.key_norm is None
 
 


### PR DESCRIPTION
Replaced the separate gated-attention projection with a single QKVG projection, including correct Qwen Q/G reordering, MLX-4bit loading, KV-sharing, and regression coverage.