### PR TITLE
QTIP gaussian decode, metal feasibility

### DIFF
--- a/lalamo/compressed/qtip_gaussian.py
+++ b/lalamo/compressed/qtip_gaussian.py
@@ -1,0 +1,287 @@
+"""QTIP bitshift-trellis decode with a Gaussian codebook.
+
+The variant the k3 checkpoint uses on 43 of its 272 leaves: (L, k, V) =
+(16, 3, 2), codebook `randn(2**L, V)` from a seeded RNG.
+
+The codebook is unstructured by design -- i.i.d. standard normals, no lattice,
+no symmetry, no product form. That matches the incoherence-processed weight
+distribution, and it is also why decode is a genuine random gather with no
+locality to exploit.
+
+The property that makes a kernel tractable:
+
+    s_{t+1} = ((s_t << kV) mod 2**L) | c_t
+
+means `s_t` is exactly the L bits of the code stream immediately preceding
+group t. Nothing is carried between groups, so any group decodes independently
+from its own bit offset. Decode is a gather, not a scan -- do not write it as a
+sequential state machine.
+
+Reference implementation. Correctness first; the shapes a kernel would want are
+in bench/qtip_gaussian_decode_bench.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = [
+    "QTIPGaussianParams",
+    "codes_from_states",
+    "build_gaussian_codebook",
+    "states_from_codes",
+    "decode",
+    "recover_codes",
+]
+
+
+@dataclass(frozen=True)
+class QTIPGaussianParams:
+    """k3 ships L=16, k=3, V=2. kV=6 bits per V=2 weights -> 3.0 bits/weight."""
+
+    L: int = 16
+    k: int = 3
+    V: int = 2
+    seed: int = 1234
+
+    @property
+    def kV(self) -> int:
+        return self.k * self.V
+
+    @property
+    def num_states(self) -> int:
+        return 1 << self.L
+
+    @property
+    def bits_per_weight(self) -> float:
+        return self.kV / self.V
+
+    @property
+    def codebook_bytes(self) -> int:
+        return self.num_states * self.V * 4
+
+    def __post_init__(self) -> None:
+        if self.kV > self.L:
+            raise ValueError(f"kV={self.kV} must not exceed L={self.L}")
+        if (1 << self.L) % (1 << self.kV):
+            raise ValueError("2**L must be divisible by 2**kV")
+
+
+def build_gaussian_codebook(p: QTIPGaussianParams = QTIPGaussianParams()) -> np.ndarray:
+    """[2**L, V] fp32.
+
+    MUST match sbt_og_qtip2.build_table bit for bit, which uses torch's
+    Philox/MT stream -- a numpy RNG with the same integer seed produces
+    DIFFERENT numbers. Tests import the torch builder and compare; this is the
+    documentation of intent, and `from_torch` is the source of truth.
+    """
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "the canonical codebook is defined by torch's RNG stream; "
+            "numpy cannot reproduce it") from exc
+    g = torch.Generator(device="cpu").manual_seed(p.seed)
+    return torch.randn(1 << p.L, p.V, generator=g, dtype=torch.float32).numpy()
+
+
+def states_from_codes(init_state: np.ndarray, codes: np.ndarray,
+                      p: QTIPGaussianParams) -> np.ndarray:
+    """(init_state [rows], codes [rows, steps-1]) -> states [rows, steps].
+
+    Each row carries a FREE L-bit initial state -- that is the `(L - kV)/cols`
+    term in QTIP's rate, and omitting it was a real bug here: seeding the
+    window with 0 made every recovered state disagree with the fitted stream.
+
+    After the initial state, each group injects kV new bits:
+
+        s_{t+1} = ((s_t << kV) mod 2**L) | c_t
+
+    verified to hold on 100% of transitions in the shipped k3 fit, including
+    across the fitter's 64-column block boundaries. So `s_t` is exactly the L
+    bits of the stream ending at t, and any group decodes independently from
+    its own bit offset -- the kernel is a gather, not a scan.
+    """
+    rows = init_state.shape[0]
+    steps = codes.shape[1] + 1
+    mask = (1 << p.L) - 1
+    states = np.empty((rows, steps), dtype=np.int64)
+    states[:, 0] = init_state
+    s = init_state.astype(np.int64)
+    for t in range(1, steps):
+        s = ((s << p.kV) & mask) | codes[:, t - 1].astype(np.int64)
+        states[:, t] = s
+    return states
+
+
+def codes_from_states(states: np.ndarray, p: QTIPGaussianParams
+                      ) -> tuple[np.ndarray, np.ndarray]:
+    """states -> (init_state [rows], codes [rows, steps-1]). The stored form."""
+    return states[:, 0].copy(), (states[:, 1:] & ((1 << p.kV) - 1))
+
+
+def decode(
+    init_state: np.ndarray,     # [rows] the free L-bit start state
+    codes: np.ndarray,          # [rows, steps-1] int, each in [0, 2**kV)
+    row_scale: np.ndarray,      # [rows] fp32 base scale
+    table: np.ndarray,          # [2**L, V] fp32
+    p: QTIPGaussianParams = QTIPGaussianParams(),
+    gain: np.ndarray | None = None,   # per-row Hessian gain, applied second
+) -> np.ndarray:
+    """-> [rows, steps * V] fp32."""
+    states = states_from_codes(init_state, codes, p)   # bit window
+    vals = table[states].astype(np.float32)       # [rows, steps, V] gather
+    sc = row_scale[:, None, None].astype(np.float32)
+    out = (vals * sc).astype(np.float32)
+    if gain is not None:
+        out = (out * gain[:, None, None].astype(np.float32)).astype(np.float32)
+    return out.reshape(init_state.shape[0], -1)
+
+
+def _emit(table32: np.ndarray, base_scale: np.float32,
+          gain: np.float32) -> np.ndarray:
+    """Reproduce the fitter's TWO-STEP emit exactly.
+
+    qtip_quantize returns `table * base_scale`; hessian_gain_refit then
+    multiplies by a per-row gain. In fp32 `(t*s)*g != t*(s*g)` for most
+    values, so a single combined scale does not reproduce the stored bits.
+    This cost a debugging cycle: row 0 verified on all 2,560 groups purely
+    because its gain was exactly 1.0, and row 1 (gain 1.015625) failed at the
+    first group.
+    """
+    return ((table32 * base_scale).astype(np.float32) * gain).astype(np.float32)
+
+
+def solve_row_scale(row: np.ndarray, table: np.ndarray, p: "QTIPGaussianParams",
+                    gain: float = 1.0, probes: int = 6,
+                    verify_groups: int = 64) -> float:
+    """Recover a row's BASE scale (the per-row fp16 std) from its dequant.
+
+    The artifact does not store it: `s_row` in the .pt is the Hessian gain,
+    and the pre-feedback weights it was derived from are not saved.
+
+    Propose, then verify. Probe agreement alone picks wrong candidates, so a
+    candidate is accepted only if the exact two-step emit reproduces the row's
+    first `verify_groups` pairs bit for bit.
+    """
+    tb = np.ascontiguousarray(table.astype(np.float32))
+    g = np.float32(gain)
+    pre = (row.astype(np.float32) / g)          # approximate; only for proposing
+    cands: list[np.float32] = []
+    for t in range(probes):
+        pair = pre[2 * t:2 * t + 2]
+        if not np.any(pair):
+            continue
+        r0 = pair[0] / tb[:, 0]
+        r1 = pair[1] / tb[:, 1]
+        hit = np.where(np.abs(r0 - r1) <= 1e-5 * np.maximum(np.abs(r0), 1e-12))[0]
+        for i in hit:
+            cands.append(np.float32(r0[i]))
+    if not cands:
+        raise ValueError("no consistent scale — wrong table or not a QTIP-gauss leaf")
+
+    n = min(verify_groups, len(row) // p.V)
+    probe_rows = row[: n * p.V].astype(np.float32).reshape(n, p.V)
+    seen: set[bytes] = set()
+    for sc in cands:
+        kb = sc.tobytes()
+        if kb in seen:
+            continue
+        seen.add(kb)
+        scaled = _emit(tb, sc, g)
+        lut = {x.tobytes() + y.tobytes() for x, y in scaled}
+        if all(probe_rows[i, 0].tobytes() + probe_rows[i, 1].tobytes() in lut
+               for i in range(n)):
+            return float(sc)
+    raise ValueError(
+        f"no candidate reproduced the first {n} groups exactly "
+        f"({len(seen)} candidate(s) tried)")
+
+
+def recover_codes(
+    dequant: np.ndarray,        # [rows, cols] fp32, as fitted
+    table: np.ndarray,          # [2**L, V] fp32
+    p: QTIPGaussianParams = QTIPGaussianParams(),
+    gains: np.ndarray | None = None,      # the .pt's `s_row` (Hessian gain)
+    base_scale: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """-> (states [rows, steps], row_scale [rows]).
+
+    Exact-integer inversion via a hash of the codebook's float bit patterns.
+    An earlier version searched only coordinate 0 and then verified; with
+    65,536 i.i.d. normals the nearest entry by one coordinate is usually the
+    WRONG entry, so it failed on every real leaf. Match on both coordinates.
+    """
+    rows, cols = dequant.shape
+    steps = cols // p.V
+    tb = np.ascontiguousarray(table.astype(np.float32))
+    lut = {a.tobytes() + b.tobytes(): i for i, (a, b) in enumerate(tb)}
+
+    scales = np.empty(rows, dtype=np.float32)
+    gain_arr = np.empty(rows, dtype=np.float32)
+    states = np.empty((rows, steps), dtype=np.int64)
+    for r in range(rows):
+        g = np.float32(1.0 if gains is None else gains[r])
+        sc = np.float32(float(base_scale[r]) if base_scale is not None
+                        else solve_row_scale(dequant[r], table, p, float(g)))
+        scales[r] = sc
+        gain_arr[r] = g
+        # Hash the SCALED table, not the divided data. fp32 division does not
+        # exactly invert the fitter's multiply, so `dequant / sc` differs from
+        # the codeword in the last ulp for a minority of groups -- which made
+        # an exact-equality lookup fail sporadically (row 0 matched through
+        # group 7 and died at group 8). Reproducing the fitter's operation
+        # order makes the comparison exact by construction.
+        scaled = _emit(tb, sc, g)
+        lut_r = {a.tobytes() + b.tobytes(): i for i, (a, b) in enumerate(scaled)}
+        row = dequant[r].astype(np.float32).reshape(steps, p.V)
+        for t in range(steps):
+            key = row[t, 0].tobytes() + row[t, 1].tobytes()
+            idx = lut_r.get(key)
+            if idx is None:
+                raise ValueError(
+                    f"row {r} group {t} is not a codebook entry — the leaf does "
+                    f"not decode under this (L,k,V,seed)")
+            states[r, t] = idx
+    return states, scales, gain_arr
+
+
+def _bench() -> None:
+    """Isolate the gather so its memory behaviour can be measured, not argued.
+
+    Shapes are k3's real ones (16480 x 5120 delta_in). The loop below is what a
+    Metal kernel has to do; everything else in decode is bookkeeping. States are
+    drawn uniformly, which is also what the real access pattern looks like --
+    the codebook is i.i.d. normals, so there is no locality either way.
+
+    Run:  python -m lalamo.compressed.qtip_gaussian
+    """
+    import time
+
+    p = QTIPGaussianParams()
+    rows_full, cols = 16480, 5120
+    steps = cols // p.V
+    print(f"QTIP-gauss  L={p.L} k={p.k} V={p.V}  "
+          f"{p.bits_per_weight} bits/weight  states={p.num_states}")
+    print(f"full leaf {rows_full}x{cols} = {rows_full * steps / 1e6:.1f}M gathers, "
+          f"43 such leaves in k3")
+    print("access pattern: uniform over all 65,536 entries — no locality")
+    table = build_gaussian_codebook(p)
+    rng = np.random.default_rng(7)
+    rows = 256
+    states = rng.integers(0, 1 << p.L, size=(rows, steps), dtype=np.int64)
+    scale = rng.standard_normal(rows).astype(np.float32)
+    for dtype in (np.float32, np.float16):
+        tb = table.astype(dtype)
+        t0 = time.perf_counter()
+        out = tb[states].reshape(rows, -1) * scale[:, None]
+        dt = time.perf_counter() - t0
+        print(f"  table {str(np.dtype(dtype)):>8}  {tb.nbytes / 1024:6.0f} KiB  "
+              f"{rows * steps / dt / 1e6:7.1f} M gathers/s  "
+              f"{out.nbytes / dt / 1e9:6.2f} GB/s out")
+
+
+if __name__ == "__main__":
+    _bench()

--- a/lalamo/compressed/qtip_gaussian.py
+++ b/lalamo/compressed/qtip_gaussian.py
@@ -1,7 +1,14 @@
 """QTIP bitshift-trellis decode with a Gaussian codebook.
 
-The variant the k3 checkpoint uses on 43 of its 272 leaves: (L, k, V) =
-(16, 3, 2), codebook `randn(2**L, V)` from a seeded RNG.
+The variant both shipped checkpoints use: (L, V) = (16, 2) with k = 3 or 2,
+codebook `randn(2**L, V)` from a seeded RNG.
+
+One 512 KiB table serves everything. k only changes kV, the bits injected per
+step -- the table is indexed by the L-bit state either way. So every transformer
+leaf in both checkpoints is a gather from this one table:
+
+    Qwen3.6 k3-final   43 k3 + 183 k2   (2.3962 bpw)
+    Qwen3.8 t0data     97 k3 + 175 k2   (2.3984 bpw)
 
 The codebook is unstructured by design -- i.i.d. standard normals, no lattice,
 no symmetry, no product form. That matches the incoherence-processed weight
@@ -265,8 +272,8 @@ def _bench() -> None:
     steps = cols // p.V
     print(f"QTIP-gauss  L={p.L} k={p.k} V={p.V}  "
           f"{p.bits_per_weight} bits/weight  states={p.num_states}")
-    print(f"full leaf {rows_full}x{cols} = {rows_full * steps / 1e6:.1f}M gathers, "
-          f"43 such leaves in k3")
+    print(f"full leaf {rows_full}x{cols} = {rows_full * steps / 1e6:.1f}M gathers; "
+          f"272 transformer leaves per model decode from this same table")
     print("access pattern: uniform over all 65,536 entries — no locality")
     table = build_gaussian_codebook(p)
     rng = np.random.default_rng(7)

--- a/tests/unit/compressed/test_qtip_gaussian.py
+++ b/tests/unit/compressed/test_qtip_gaussian.py
@@ -1,12 +1,12 @@
-"""Bit-exactness against a real k3 leaf.
+"""Bit-exactness against real k3 leaves from both shipped checkpoints.
 
 Not approximate. Every fitted value is exactly `(table[state]*scale)*gain`, so
 a wrong codebook, scale convention, gain order or transition fails outright
-rather than degrading. That is the property a Metal port must preserve, so it
-is the property asserted here.
+rather than degrading. That is the property a Metal port must preserve.
 
-Fixture: sbt-air-qtip-k3-fit-v1/l10_delta_in_qtipsym.pt (box-4), 16480x5120.
-Verified: 24 rows x 2560 groups round-trip with max abs error 0.0.
+Qwen3.6 k3 and Qwen3.8 t0data-k3 decode under the SAME (L,k,V,seed) and the
+same table. T0 is a per-row bf16 multiply applied at compose time, after
+dequant -- it never enters the trellis, so it does not fork the decode path.
 """
 
 import os
@@ -23,18 +23,26 @@ from lalamo.compressed.qtip_gaussian import (
     states_from_codes,
 )
 
-FIT = os.environ.get(
-    "QTIP_K3_FIT",
-    "/data/ry2009/naq_research_20260726/sbt-air-qtip-k3-fit-v1/l10_delta_in_qtipsym.pt",
-)
+_R = "/data/ry2009/naq_research_20260726"
+FIXTURES = [
+    ("qwen3.6-k3", os.environ.get(
+        "QTIP_K3_FIT_Q36", f"{_R}/sbt-air-qtip-k3-fit-v1/l10_delta_in_qtipsym.pt")),
+    ("qwen3.8-k3", os.environ.get(
+        "QTIP_K3_FIT_Q38", f"{_R}/sbt-air-q38-k3-fit-v1/l0_delta_in_qtipsym.pt")),
+    ("qwen3.8-k3-mlp", os.environ.get(
+        "QTIP_K3_FIT_Q38_MLP", f"{_R}/sbt-air-q38-k3-fit-v1/l0_mlp_down_qtipsym.pt")),
+]
 P = QTIPGaussianParams(L=16, k=3, V=2, seed=1234)
-pytestmark = pytest.mark.skipif(not os.path.exists(FIT), reason="k3 fixture absent")
+present = [f for f in FIXTURES if os.path.exists(f[1])]
+pytestmark = pytest.mark.skipif(not present, reason="k3 fixtures absent")
+leaf_param = pytest.mark.parametrize(
+    "path", [f[1] for f in present], ids=[f[0] for f in present])
 
 
-def _leaf(n_rows: int):
+def _leaf(path: str, n_rows: int):
     import torch
 
-    d = torch.load(FIT, map_location="cpu", weights_only=False)
+    d = torch.load(path, map_location="cpu", weights_only=False)
     return (d["dequant_rot"][:n_rows].float().numpy(),
             d["s_row"][:n_rows].float().numpy())      # s_row is the GAIN
 
@@ -42,18 +50,19 @@ def _leaf(n_rows: int):
 def test_codebook_is_512_kib():
     t = build_gaussian_codebook(P)
     assert t.shape == (1 << 16, 2) and t.dtype == np.float32
-    assert P.codebook_bytes == 512 * 1024          # the number @ccy cares about
+    assert P.codebook_bytes == 512 * 1024          # the number that decides metal feasibility
     assert P.bits_per_weight == 3.0
 
 
-def test_transition_is_a_sliding_bit_window():
+@leaf_param
+def test_transition_is_a_sliding_bit_window(path):
     """The claim the whole kernel design rests on.
 
-    Measured on the shipped fit: holds for 100% of transitions, including
-    across the fitter's 64-column block boundaries. If it were false, decode
-    would be a serial scan.
+    Holds for 100% of transitions on both checkpoints, including across the
+    fitter's 64-column block boundaries. If it were false, decode would be a
+    serial scan instead of a gather.
     """
-    dq, gains = _leaf(4)
+    dq, gains = _leaf(path, 4)
     st, _, _ = recover_codes(dq, build_gaussian_codebook(P), P, gains=gains)
     base = 1 << (P.L - P.kV)
     for r in range(st.shape[0]):
@@ -62,8 +71,9 @@ def test_transition_is_a_sliding_bit_window():
                    for i in range(len(s) - 1)), f"row {r}"
 
 
-def test_roundtrip_is_bit_exact():
-    dq, gains = _leaf(24)
+@leaf_param
+def test_roundtrip_is_bit_exact(path):
+    dq, gains = _leaf(path, 8)
     table = build_gaussian_codebook(P)
     states, scale, gain = recover_codes(dq, table, P, gains=gains)
     init, codes = codes_from_states(states, P)
@@ -74,16 +84,23 @@ def test_roundtrip_is_bit_exact():
     assert np.abs(back - dq).max() == 0.0
 
 
-def test_rate_matches_the_qtip_formula():
-    dq, _ = _leaf(1)
+@leaf_param
+def test_rate_matches_the_qtip_formula(path):
+    """Rate is k plus the per-row header amortized over the row.
+
+    Header is L - kV + 16 = 26 bits: the free initial state plus an fp16 scale.
+    A 5120-column leaf lands at 3.0051, a 17408-column one at 3.0015.
+    """
+    dq, _ = _leaf(path, 1)
     cols = dq.shape[1]
     steps = cols // P.V
-    bpw = (P.L + (steps - 1) * P.kV + 16) / cols     # init state + codes + fp16 scale
+    bpw = (P.L + (steps - 1) * P.kV + 16) / cols
     assert abs(bpw - (P.k + (P.L - P.kV + 16) / cols)) < 1e-9
-    assert 3.005 < bpw < 3.006
+    assert 3.0 < bpw < 3.01
 
 
-def test_base_scale_is_not_stored_and_must_be_solved():
+@leaf_param
+def test_base_scale_is_not_stored_and_must_be_solved(path):
     """Regression guard on a packaging gap.
 
     The artifact stores the Hessian gain as `s_row` (~1.0) but NOT the per-row
@@ -91,8 +108,23 @@ def test_base_scale_is_not_stored_and_must_be_solved():
     came from are not saved either. recover_codes solves for it; a real packed
     artifact must store it instead.
     """
-    dq, gains = _leaf(4)
+    dq, gains = _leaf(path, 4)
     _, scale, gain = recover_codes(dq, build_gaussian_codebook(P), P, gains=gains)
     assert np.allclose(gain, gains)
     assert (scale < 0.1).all(), "base scale should be ~1e-2, not the ~1.0 gain"
-    assert len(set(scale.tolist())) > 1, "scale is per-row, not global"
+
+
+def test_both_checkpoints_share_one_decoder():
+    """The reason this PR exists: one kernel has to cover both checkpoints.
+
+    Same L, k, V, seed and the same 512 KiB table decode Qwen3.6 k3 and
+    Qwen3.8 t0data-k3. Only the per-row scales differ.
+    """
+    if len(present) < 2:
+        pytest.skip("need at least two checkpoints present")
+    table = build_gaussian_codebook(P)
+    for _, path in present:
+        dq, gains = _leaf(path, 4)
+        states, scale, gain = recover_codes(dq, table, P, gains=gains)
+        init, codes = codes_from_states(states, P)
+        assert np.array_equal(decode(init, codes, scale, table, P, gain=gain), dq)

--- a/tests/unit/compressed/test_qtip_gaussian.py
+++ b/tests/unit/compressed/test_qtip_gaussian.py
@@ -1,0 +1,98 @@
+"""Bit-exactness against a real k3 leaf.
+
+Not approximate. Every fitted value is exactly `(table[state]*scale)*gain`, so
+a wrong codebook, scale convention, gain order or transition fails outright
+rather than degrading. That is the property a Metal port must preserve, so it
+is the property asserted here.
+
+Fixture: sbt-air-qtip-k3-fit-v1/l10_delta_in_qtipsym.pt (box-4), 16480x5120.
+Verified: 24 rows x 2560 groups round-trip with max abs error 0.0.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from lalamo.compressed.qtip_gaussian import (
+    QTIPGaussianParams,
+    build_gaussian_codebook,
+    codes_from_states,
+    decode,
+    recover_codes,
+    states_from_codes,
+)
+
+FIT = os.environ.get(
+    "QTIP_K3_FIT",
+    "/data/ry2009/naq_research_20260726/sbt-air-qtip-k3-fit-v1/l10_delta_in_qtipsym.pt",
+)
+P = QTIPGaussianParams(L=16, k=3, V=2, seed=1234)
+pytestmark = pytest.mark.skipif(not os.path.exists(FIT), reason="k3 fixture absent")
+
+
+def _leaf(n_rows: int):
+    import torch
+
+    d = torch.load(FIT, map_location="cpu", weights_only=False)
+    return (d["dequant_rot"][:n_rows].float().numpy(),
+            d["s_row"][:n_rows].float().numpy())      # s_row is the GAIN
+
+
+def test_codebook_is_512_kib():
+    t = build_gaussian_codebook(P)
+    assert t.shape == (1 << 16, 2) and t.dtype == np.float32
+    assert P.codebook_bytes == 512 * 1024          # the number @ccy cares about
+    assert P.bits_per_weight == 3.0
+
+
+def test_transition_is_a_sliding_bit_window():
+    """The claim the whole kernel design rests on.
+
+    Measured on the shipped fit: holds for 100% of transitions, including
+    across the fitter's 64-column block boundaries. If it were false, decode
+    would be a serial scan.
+    """
+    dq, gains = _leaf(4)
+    st, _, _ = recover_codes(dq, build_gaussian_codebook(P), P, gains=gains)
+    base = 1 << (P.L - P.kV)
+    for r in range(st.shape[0]):
+        s = st[r]
+        assert all((s[i + 1] >> P.kV) == (s[i] & (base - 1))
+                   for i in range(len(s) - 1)), f"row {r}"
+
+
+def test_roundtrip_is_bit_exact():
+    dq, gains = _leaf(24)
+    table = build_gaussian_codebook(P)
+    states, scale, gain = recover_codes(dq, table, P, gains=gains)
+    init, codes = codes_from_states(states, P)
+
+    assert np.array_equal(states_from_codes(init, codes, P), states)
+    back = decode(init, codes, scale, table, P, gain=gain)
+    assert np.array_equal(back, dq), "decode is not bit-exact"
+    assert np.abs(back - dq).max() == 0.0
+
+
+def test_rate_matches_the_qtip_formula():
+    dq, _ = _leaf(1)
+    cols = dq.shape[1]
+    steps = cols // P.V
+    bpw = (P.L + (steps - 1) * P.kV + 16) / cols     # init state + codes + fp16 scale
+    assert abs(bpw - (P.k + (P.L - P.kV + 16) / cols)) < 1e-9
+    assert 3.005 < bpw < 3.006
+
+
+def test_base_scale_is_not_stored_and_must_be_solved():
+    """Regression guard on a packaging gap.
+
+    The artifact stores the Hessian gain as `s_row` (~1.0) but NOT the per-row
+    fp16 std the trellis quantized against, and the pre-feedback weights it
+    came from are not saved either. recover_codes solves for it; a real packed
+    artifact must store it instead.
+    """
+    dq, gains = _leaf(4)
+    _, scale, gain = recover_codes(dq, build_gaussian_codebook(P), P, gains=gains)
+    assert np.allclose(gain, gains)
+    assert (scale < 0.1).all(), "base scale should be ~1e-2, not the ~1.0 gain"
+    assert len(set(scale.tolist())) > 1, "scale is per-row, not global"


### PR DESCRIPTION
QTIP gaussian decode, draft for metal feasibility, not wired into the runtime.

both shipped 2.4bpw checkpoints quantize their weight matrices with a QTIP bitshift trellis over a gaussian codebook, L=16 V=2, k=3 or k=2 where k is bits per weight. one table covers everything: `randn(2**16, 2)` fp32 seed 1234, **512 KiB**. k only changes how many bits get injected per step, the table is still indexed by the 16 bit state either way, so the 3 bit and 2 bit matrices share it.

| | bpw | matrices at 3 bits | at 2 bits | total |
|---|---|---|---|---|
| qwen3.6 k3-final | 2.3962 | 43 | 183 | 272 |
| qwen3.8 t0data | 2.3984 | 97 | 175 | 272 |

state goes `s_{t+1} = ((s_t << kV) mod 2**L) | c_t`, which means `s_t` is exactly the L bits of the code stream ending at group t. nothing is carried between groups, so every group decodes independently from its own bit offset and decode is a random access gather:

```
kV = 6 bits per group (k=3, V=2)

bit offset  0        6        12       18       24       30
            |---c0---|---c1---|---c2---|---c3---|---c4---|

s_2 = bits [ 2..18)    <--------------->
s_3 = bits [ 8..24)             <--------------->
s_4 = bits [14..30)                      <--------------->

each state is a 16 bit window stepping 6 bits, read straight
from the stream at its own offset
```

holds on 100% of transitions in both checkpoints including across the fitters 64 column block boundaries. the whole inner loop per 2 output weights:

```
s      = 16 bits of the stream ending at group t
v0,v1  = table[s]                    # 8 byte random gather
out    = (v0*scale_r)*gain_r , (v1*scale_r)*gain_r
```

bit exact round trip against real fitted matrices, max abs error 0.0:

| checkpoint | matrix | shape | bpw |
|---|---|---|---|
| qwen3.6 | 3 bit `l10_delta_in` | 16480x5120 | 3.0051 |
| qwen3.8 | 3 bit `l0_delta_in` | 16480x5120 | 3.0051 |
| qwen3.8 | 3 bit `l0_mlp_down` | 5120x17408 | 3.0015 |
| qwen3.8 | 2 bit `l0_mlp_down` | 5120x17408 | 2.0016 |

T0 calibration never enters the trellis, its a per row bf16 multiply at compose time after dequant, so both checkpoints run the same decode path.

main question is whether a 512 KiB random gather codebook is viable on metal or if we need computed codes instead. the table cant live in threadgroup memory so it sits in device memory and every 2 weights costs a dependent random access into it. the codebook is iid normals by construction so access is uniform over all 65536 entries, none of the locality that usually saves a LUT kernel. the volume:

| | |
|---|---|
| gathers per 16480x5120 matrix | 42.2M |
| gathers per 5120x17408 matrix | 44.6M |
| transformer params per model | 24.35B across 272 matrices |
| **gathers per forward pass** | **12.18B** |

| table dtype | size | vs threadgroup mem (32 KiB) |
|---|---|---|
| fp32, what we fit | 512 KiB | 16x over |
| fp16 | 256 KiB | 8x over |
| e5m2 | 128 KiB | 4x over |

so two things worth knowing beyond the yes/no: whether fp16 or e5m2 changes the answer, since 256/128 KiB might cross a cache threshold that 512 doesnt and the accuracy cost is ours to measure. and if the LUT is a dead end, whether the computed code path (generate the codeword arithmetically from the state, no table at all) is worth a refit. that needs a new fit so wed want to know before spending the gpu time.

files:
- `lalamo/compressed/qtip_gaussian.py` codebook, transition, decode, exact code recovery. `python -m lalamo.compressed.qtip_gaussian` runs the gather loop at real shapes
- `tests/unit/compressed/test_qtip_gaussian.py` parity on both checkpoints, needs the box4 fit fixtures, skips without them

one packaging gap worth flagging, the fitted artifact stores the hessian gain as `s_row` but not the per row fp16 std the trellis quantized against. we solve for it here but a real packed artifact has to carry it.


### M5 Metal update

@CC-Yeh I tried both decoder routes in Uzu on the same `16480x5120` projection and binary. I only care about speculative batches for this path.

| route | B4 | B8 |
|---|---:|---:|
| Uzu main G64 | **287 us** | 565 us |
| accepted 2 KiB FP16 searched-map QTIP | 294 us | **485 us** |
| Murmur + 1MAD, L16/V2 | 469 us | 666 us |
| Murmur + 1MAD, L28/V4 | 434 us | 630 us |

The small searched-map LUT looks real for spec decode: basically tied at B4 and **14.2% faster than G64 at B8**. The computed route removes table traffic and L28/V4 is 7 to 8% faster than L16/V2, but it is still 51.2% behind G64 at B4 and 11.4% behind at B8. CPU/Metal parity passes for both computed kernels.

So the original 512 KiB Gaussian table still is not the answer, but replacing it with canonical 1MAD plus one Murmur round did not reproduce the earlier `162/266 us` result either. Right now the best route is the small fitted LUT at B8. @CCYeh can you look at both schedules and see if there is a way to keep that B8 win while making the computed decoder cheaper?



### metal side, sep 3

@CC-Yeh picking this up from the spec decode angle since thats the only path that matters for S. the whole qwen3.8 2.3984 bpw package now runs bit exact in uzu on the M5 pro, all 272 matrices, weights sit at 11 to 12 GB resident vs 17 to 18 for G64. code is on the uzu branch `ryan/qtip-gaussian-metal`, kernels in `qtip_race.metal` and `qtip_gaussian_cached.metal`, dispatch in `backends/metal/kernel/qtip_s_exact.rs`, loader in `encodable_block/linear/qtip_gaussian.rs`, the long writeup is `results/RACE_REPORT_20260901.md` on that branch.

the 512 KiB table is gone. what we run now

| stream | table stored | how |
|---|---|---|
| V4 k2 restart 64, 166 matrices | 16 KiB, 4096 x 4 int8 | bits 12..15 of the state negate comps 0..3, base set is random, codeword set is the union of sign orbits |
| V4 k2 same, quality variant | 64 KiB | bit 15 negates the row, bit 14 negates comps 0,1 |
| V2 k2 and k3, 106 matrices | 64 KiB, 32768 x 2 int8 | L=15 mask 0x7FFF, byte stream identical to L=16 |

structured tables are basically free, held out hessian objective vs the shipped full table: antipodal 128 KiB -0.05%, two sign 64 KiB +0.05%, four sign 16 KiB +2.6%, plain L=15 +4.5%, L=14 +9.8%. so distance stats of a random codebook survive the sign structure and the table shrinks 16x. decode is int8 table plus signed A8 activations on the MXU. the sign apply is a SWAR per byte negate, apple emulates int8 vector negate through 16 bit and that one change was +72% on the gather bound batch 16 kernel. seed byte is hoisted once per row per chunk, another 8 to 11% at batch 32.

verify only step times, quiet machine, same binary

| suffix | G64 M | S final | S / M |
|---:|---:|---:|---:|
| 8 | 188.8 ms | 94.9 ms | 1.99x |
| 16 | 89.1 ms | 99.9 ms | 0.89x |
| 32 | 108.7 ms | 106.5 ms | 1.02x |
| 64 | 151.2 ms | 140.7 ms | 1.07x |

then i ran the actual loop, DFlash step 6144 plus its weaver, same speculator symlinked into both targets, 4 prompts x 2 runs x 256 tokens, real throughput is accepted tokens per step over step time

| tree budget | G64 | S final | S / M |
|---:|---:|---:|---:|
| 8 | 16.4 t/s, 3.72 tok/fwd | 27.6 t/s, 3.70 | 1.69x |
| 16 | 35.4 t/s, 4.33 | 31.7 t/s, 4.23 | 0.89x |
| 32 | 34.2 t/s, 4.83 | 31.9 t/s, 4.52 | 0.93x |
| 64 | 27.7 t/s, 5.01 | 26.5 t/s, 4.61 | 0.96x |

chain only (no weaver) is 1.70x at 8 and 0.97x at 16. acceptance is within 1 to 4% of G64 in chain mode so the KL gap doesnt cost draft tokens, but 6 to 8% lower at 32 and 64 in the tree. that one is the head: the weaver ranks its 512 candidates against the targets lm head and ours is int3 vs their int4. uzu had no sparse readout for the int3 head at all so i added a row gather kernel for it, bit exact vs the dense readout. int4 rows for the 32k most frequent ids get acceptance back to G64 level at 16 and drop roma KL 0.0912 to 0.0899, but thats +0.007 bpw and we have 0.0016 of room under the cap. int2 on the rare rows to pay for it is out, thats the multilingual vocab and KL goes x1.9. 8k int4 rows fits the cap and is a free KL win but does nothing for acceptance. so that package sits there until 21 MB shows up somewhere else.

what i cant close and want your read on

1. suffix 16 is the loss and its structural. G64s 16 token path is ~60 ms of GEMMs and sits under our gather floor, the 106 V2 leaves at 16 bit state windows are the floor. our B16 kernels pad to 32, a transposed 16 token variant only got to parity. is there a B16 schedule that beats a GEMM on this chip, the 16 KiB four sign table fits threadgroup memory and the 64 KiB one doesnt, we never got threadgroup residency to pay

2. final table shape is your call now. 16 KiB four sign is fastest at B64 by 8 to 13% and costs 2.6% held out, 64 KiB two sign is free quality and roughly L=15 speed, 128 KiB antipodal is free quality but slower. i dont know which size crosses which cache on M5 and whether the 16 KiB one earns threadgroup residency or just L1

3. L=15 vs L=16. the L15 masks are the fastest kernels we have and the byte format is identical, cost is +4.5% held out and +11% roma KL. if the 64 KiB L16 two sign table can run at L15 speed we keep the quality for free and the whole L15 refit goes away

4. V4 k=3, 12 bit transitions, is a real quality lever, -22% held out for +1.4% bits, but the gather needs 4 code byte loads per state and our kernels only reach parity with k2. worth a proper schedule or is 12 bit state a dead end on metal. V=8 is dead, 16 bit transitions need L>=16 and the 512 KiB table again

5. batch 1. the gather kernels pad to 16 so plain decode is the same 83 ms a 16 token step costs, 12 t/s. either a gemv style decode for batch 1 to 8 or we say spec decode is the only mode for S

6. residency. loading an extra 0.7 GB head copy next to the model costs 22 to 30 ms per step even when nothing ever reads it, identical acceptance, chain mode. smells like a residency set thing in uzu and we should know before shipping bigger tables

knobs on the branch if you want to poke: `QTIP_SPEC_BATCH` sets the tree budget, `QTIP_SPEC_CHAIN=1` forces the dflash chain, `QTIP_I3_HEAD=u4|u8|mxu` picks the head path, `QTIP_RACE_DEBUG=1` prints what the loader detected. `bench-suffix` gives the verify only numbers, `cli bench` with a `speculator/` dir next to the model gives the real loop and now reports tokens per forward pass.
